### PR TITLE
[PPLE-181,PPLE-182] Get announcement endpoints

### DIFF
--- a/.changeset/quick-heads-begin.md
+++ b/.changeset/quick-heads-begin.md
@@ -1,0 +1,6 @@
+---
+'@api/backoffice': minor
+---
+
+[PPLE-182] Get announcement by id endpoint
+[PPLE-181] Get list of announcements

--- a/apps-api/backoffice/prisma/seed.ts
+++ b/apps-api/backoffice/prisma/seed.ts
@@ -1,6 +1,6 @@
 import { PrismaPg } from '@prisma/adapter-pg'
 
-import { PrismaClient, UserRole } from '../__generated__/prisma'
+import { AnnouncementType, FeedItemType, PrismaClient, UserRole } from '../__generated__/prisma'
 
 const connectionString = `${process.env.DATABASE_URL}`
 
@@ -9,25 +9,120 @@ const prisma = new PrismaClient({
   adapter,
 })
 
+const OFFICIAL_USER_ID = 'official-user'
+
 const seedOfficialUser = async () => {
   await prisma.user.upsert({
-    where: { id: 'official-user' },
+    where: { id: OFFICIAL_USER_ID },
     update: {
       name: 'Official User',
       phoneNumber: '+1234567890',
       role: UserRole.OFFICIAL,
     },
     create: {
-      id: 'official-user',
+      id: OFFICIAL_USER_ID,
       name: 'Official User',
       phoneNumber: '+1234567890',
       role: UserRole.OFFICIAL,
     },
   })
+  console.log('Seeded official user successfully.')
+}
+
+const seedAnnouncements = async () => {
+  await prisma.feedItem.upsert({
+    where: { id: 'announcement-1' },
+    update: {},
+    create: {
+      id: 'announcement-1',
+      type: FeedItemType.ANNOUNCEMENT,
+      author: {
+        connect: { id: OFFICIAL_USER_ID },
+      },
+      announcement: {
+        create: {
+          title: 'Welcome to PPLE Today',
+          content: 'This is the first announcement on PPLE Today.',
+          type: AnnouncementType.OFFICIAL,
+          backgroundColor: '#FF5733',
+          attachments: {
+            create: [
+              {
+                url: 'https://example.com/image1.png',
+              },
+              {
+                url: 'https://example.com/image2.png',
+              },
+            ],
+          },
+        },
+      },
+    },
+  })
+  await prisma.feedItem.upsert({
+    where: { id: 'announcement-1' },
+    update: {},
+    create: {
+      id: 'announcement-2',
+      type: FeedItemType.ANNOUNCEMENT,
+      author: {
+        connect: { id: OFFICIAL_USER_ID },
+      },
+      announcement: {
+        create: {
+          title: 'Welcome to PPLE Today',
+          content: 'This is the second announcement on PPLE Today.',
+          type: AnnouncementType.OFFICIAL,
+          backgroundColor: '#33FF57',
+          attachments: {
+            create: [
+              {
+                url: 'https://example.com/image1.png',
+              },
+              {
+                url: 'https://example.com/image2.png',
+              },
+            ],
+          },
+        },
+      },
+    },
+  })
+  await prisma.feedItem.upsert({
+    where: { id: 'announcement-3' },
+    update: {},
+    create: {
+      id: 'announcement-3',
+      type: FeedItemType.ANNOUNCEMENT,
+      author: {
+        connect: { id: OFFICIAL_USER_ID },
+      },
+      announcement: {
+        create: {
+          title: 'Welcome to PPLE Today',
+          content: 'This is the third announcement on PPLE Today.',
+          type: AnnouncementType.OFFICIAL,
+          backgroundColor: '#5733FF',
+          attachments: {
+            create: [
+              {
+                url: 'https://example.com/image1.png',
+              },
+              {
+                url: 'https://example.com/image2.png',
+              },
+            ],
+          },
+        },
+      },
+    },
+  })
+  console.log('Seeded announcements successfully.')
 }
 
 async function main() {
   await seedOfficialUser()
+  await seedAnnouncements()
 }
 
 main()

--- a/apps-api/backoffice/prisma/seed.ts
+++ b/apps-api/backoffice/prisma/seed.ts
@@ -60,7 +60,7 @@ const seedAnnouncements = async () => {
     },
   })
   await prisma.feedItem.upsert({
-    where: { id: 'announcement-1' },
+    where: { id: 'announcement-2' },
     update: {},
     create: {
       id: 'announcement-2',

--- a/apps-api/backoffice/src/dtos/error.ts
+++ b/apps-api/backoffice/src/dtos/error.ts
@@ -26,6 +26,9 @@ const COMMON_ERROR_SCHEMA = {
   INTERNAL_SERVER_ERROR: {
     status: 500,
   },
+  NOT_IMPLEMENTED: {
+    status: 501,
+  },
 } satisfies InternalErrorSchemas
 
 const AUTH_ERROR_SCHEMA = {
@@ -34,6 +37,12 @@ const AUTH_ERROR_SCHEMA = {
   },
   AUTH_USER_ALREADY_EXISTS: {
     status: 409,
+  },
+} satisfies InternalErrorSchemas
+
+const ANNOUNCEMENT_ERROR_SCHEMA = {
+  ANNOUNCEMENT_NOT_FOUND: {
+    status: 404,
   },
 } satisfies InternalErrorSchemas
 
@@ -85,6 +94,7 @@ export const InternalErrorCodeSchemas = {
   ...POST_ERROR_SCHEMA,
   ...ABOUT_US_ERROR_SCHEMA,
   ...USER_ERROR_SCHEMA,
+  ...ANNOUNCEMENT_ERROR_SCHEMA,
 } as const
 export type InternalErrorCodeSchemas = typeof InternalErrorCodeSchemas
 

--- a/apps-api/backoffice/src/index.ts
+++ b/apps-api/backoffice/src/index.ts
@@ -6,6 +6,7 @@ import Elysia from 'elysia'
 import serverEnv from './config/env'
 import { InternalErrorCode } from './dtos/error'
 import { AdminController } from './modules/admin'
+import { AnnouncementsController } from './modules/announcements'
 import { AuthController } from './modules/auth'
 import { PostsController } from './modules/posts'
 import { ProfileController } from './modules/profile'
@@ -58,6 +59,7 @@ let app = new Elysia({ adapter: node() })
   .use(cors())
   .use(PostsController)
   .use(AuthController)
+  .use(AnnouncementsController)
   .use(AdminController)
   .use(ProfileController)
   .get('/versions', ({ status }) => {

--- a/apps-api/backoffice/src/modules/announcements/index.ts
+++ b/apps-api/backoffice/src/modules/announcements/index.ts
@@ -1,0 +1,99 @@
+import node from '@elysiajs/node'
+import Elysia from 'elysia'
+
+import {
+  GetAnnouncementByIdParams,
+  GetAnnouncementByIdResponse,
+  GetAnnouncementsQuery,
+  GetAnnouncementsResponse,
+} from './models'
+import { AnnouncementServicePlugin } from './services'
+
+import { InternalErrorCode } from '../../dtos/error'
+import { AuthGuardPlugin } from '../../plugins/auth-guard'
+import { createErrorSchema, exhaustiveGuard, mapErrorCodeToResponse } from '../../utils/error'
+
+export const AnnouncementsController = new Elysia({
+  prefix: '/announcements',
+  adapter: node(),
+})
+  .use([AnnouncementServicePlugin, AuthGuardPlugin])
+  .get(
+    '/',
+    async ({ announcementService, status, query }) => {
+      const result = await announcementService.getAnnouncements({
+        limit: query.limit ?? 10,
+        page: query.page ?? 1,
+      })
+
+      if (result.isErr()) {
+        return mapErrorCodeToResponse(result.error, status)
+      }
+
+      return status(200, result.value)
+    },
+    {
+      query: GetAnnouncementsQuery,
+      response: {
+        200: GetAnnouncementsResponse,
+        ...createErrorSchema(InternalErrorCode.INTERNAL_SERVER_ERROR),
+      },
+      detail: {
+        summary: 'Get all announcements',
+        description: 'Fetch a list of all announcements',
+      },
+    }
+  )
+  .get(
+    '/:id',
+    async ({ announcementService, params, status }) => {
+      const announcement = await announcementService.getAnnouncementById(params.id)
+
+      if (announcement.isErr()) {
+        switch (announcement.error.code) {
+          case InternalErrorCode.ANNOUNCEMENT_NOT_FOUND:
+            return mapErrorCodeToResponse(announcement.error, status)
+          case InternalErrorCode.INTERNAL_SERVER_ERROR:
+            return mapErrorCodeToResponse(announcement.error, status)
+          default:
+            exhaustiveGuard(announcement.error)
+        }
+      }
+
+      return status(200, announcement.value)
+    },
+    {
+      params: GetAnnouncementByIdParams,
+      response: {
+        200: GetAnnouncementByIdResponse,
+        ...createErrorSchema(
+          InternalErrorCode.ANNOUNCEMENT_NOT_FOUND,
+          InternalErrorCode.INTERNAL_SERVER_ERROR
+        ),
+      },
+      detail: {
+        summary: 'Get an announcement by ID',
+        description: 'Get a specific announcement by ID',
+      },
+    }
+  )
+  // TODO: Implement marking announcements as read after notifications are implemented
+  .post(
+    '/:id/read',
+    async ({ status }) => {
+      return mapErrorCodeToResponse(
+        {
+          code: InternalErrorCode.NOT_IMPLEMENTED,
+          message: 'Marking announcements as read is not implemented yet',
+        },
+        status
+      )
+    },
+    {
+      detail: {
+        summary: 'Mark announcement as read',
+        description: 'Mark a specific announcement as read',
+        hide: true,
+      },
+    }
+  )

--- a/apps-api/backoffice/src/modules/announcements/index.ts
+++ b/apps-api/backoffice/src/modules/announcements/index.ts
@@ -16,6 +16,7 @@ import { createErrorSchema, exhaustiveGuard, mapErrorCodeToResponse } from '../.
 export const AnnouncementsController = new Elysia({
   prefix: '/announcements',
   adapter: node(),
+  tags: ['Announcements'],
 })
   .use([AnnouncementServicePlugin, AuthGuardPlugin])
   .get(

--- a/apps-api/backoffice/src/modules/announcements/models.ts
+++ b/apps-api/backoffice/src/modules/announcements/models.ts
@@ -1,0 +1,37 @@
+import { Static, t } from 'elysia'
+
+export const GetAnnouncementsQuery = t.Object({
+  limit: t.Optional(t.Number({ default: 10 })),
+  page: t.Optional(t.Number({ default: 1 })),
+})
+export type GetAnnouncementsQuery = Static<typeof GetAnnouncementsQuery>
+
+export const GetAnnouncementsResponse = t.Object({
+  announcements: t.Array(
+    t.Object({
+      id: t.String({ description: 'The ID of the announcement' }),
+      title: t.String({ description: 'The title of the announcement' }),
+      content: t.String({ description: 'The content of the announcement' }),
+      backgroundColor: t.String({ description: 'Background color for the announcement' }),
+      createdAt: t.Date({ description: 'Creation date of the announcement' }),
+      updatedAt: t.Date({ description: 'Last update date of the announcement' }),
+    })
+  ),
+})
+export type GetAnnouncementsResponse = Static<typeof GetAnnouncementsResponse>
+
+export const GetAnnouncementByIdParams = t.Object({
+  id: t.String({ description: 'The ID of the announcement' }),
+})
+export type GetAnnouncementByIdParams = Static<typeof GetAnnouncementByIdParams>
+
+export const GetAnnouncementByIdResponse = t.Object({
+  id: t.String(),
+  title: t.String(),
+  content: t.String(),
+  backgroundColor: t.String(),
+  attachments: t.Array(t.String({ format: 'uri', description: 'Attachment URL' })),
+  createdAt: t.Date(),
+  updatedAt: t.Date(),
+})
+export type GetAnnouncementByIdResponse = Static<typeof GetAnnouncementByIdResponse>

--- a/apps-api/backoffice/src/modules/announcements/repository.ts
+++ b/apps-api/backoffice/src/modules/announcements/repository.ts
@@ -1,0 +1,68 @@
+import { Elysia } from 'elysia'
+
+import { PrismaService, PrismaServicePlugin } from '../../plugins/prisma'
+import { fromPrismaPromise } from '../../utils/prisma'
+
+export class AnnouncementRepository {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async getAnnouncements(
+    query: { limit: number; page: number } = {
+      limit: 10,
+      page: 1,
+    }
+  ) {
+    const { limit, page } = query
+    const skip = page ? (page - 1) * limit : 0
+
+    return await fromPrismaPromise(
+      this.prismaService.announcement.findMany({
+        select: {
+          feedItemId: true,
+          title: true,
+          content: true,
+          backgroundColor: true,
+          attachments: true,
+          feedItem: {
+            select: {
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+        },
+        take: limit,
+        skip,
+        orderBy: {
+          feedItem: {
+            createdAt: 'desc',
+          },
+        },
+      })
+    )
+  }
+
+  async getAnnouncementById(id: string) {
+    return await fromPrismaPromise(
+      this.prismaService.announcement.findUnique({
+        where: { feedItemId: id },
+        include: {
+          attachments: true,
+          feedItem: {
+            select: {
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+        },
+      })
+    )
+  }
+}
+
+export const AnnouncementRepositoryPlugin = new Elysia({
+  name: 'AnnouncementRepository',
+})
+  .use(PrismaServicePlugin)
+  .decorate(({ prismaService }) => ({
+    announcementRepository: new AnnouncementRepository(prismaService),
+  }))

--- a/apps-api/backoffice/src/modules/announcements/services.ts
+++ b/apps-api/backoffice/src/modules/announcements/services.ts
@@ -1,0 +1,64 @@
+import Elysia from 'elysia'
+import { err, ok } from 'neverthrow'
+
+import { GetAnnouncementByIdResponse, GetAnnouncementsResponse } from './models'
+import { AnnouncementRepository, AnnouncementRepositoryPlugin } from './repository'
+
+import { InternalErrorCode } from '../../dtos/error'
+import { mapRawPrismaError } from '../../utils/prisma'
+
+export class AnnouncementService {
+  constructor(private readonly announcementRepository: AnnouncementRepository) {}
+
+  async getAnnouncements(query?: { limit: number; page: number }) {
+    const announcementResult = await this.announcementRepository.getAnnouncements(query)
+
+    if (announcementResult.isErr()) {
+      return mapRawPrismaError(announcementResult.error)
+    }
+
+    return ok({
+      announcements: announcementResult.value.map((announcement) => ({
+        id: announcement.feedItemId,
+        title: announcement.title,
+        content: announcement.content ?? '',
+        backgroundColor: announcement.backgroundColor ?? '',
+        createdAt: announcement.feedItem.createdAt,
+        updatedAt: announcement.feedItem.updatedAt,
+      })),
+    } satisfies GetAnnouncementsResponse)
+  }
+
+  async getAnnouncementById(id: string) {
+    const announcementResult = await this.announcementRepository.getAnnouncementById(id)
+
+    if (announcementResult.isErr()) {
+      return mapRawPrismaError(announcementResult.error)
+    }
+
+    if (!announcementResult.value) {
+      return err({
+        code: InternalErrorCode.ANNOUNCEMENT_NOT_FOUND,
+        message: 'Announcement not found',
+      })
+    }
+
+    return ok({
+      id: announcementResult.value.feedItemId,
+      title: announcementResult.value.title,
+      content: announcementResult.value.content ?? '',
+      backgroundColor: announcementResult.value.backgroundColor ?? '',
+      attachments: announcementResult.value.attachments.map((attachment) => attachment.url),
+      createdAt: announcementResult.value.feedItem.createdAt,
+      updatedAt: announcementResult.value.feedItem.updatedAt,
+    } satisfies GetAnnouncementByIdResponse)
+  }
+}
+
+export const AnnouncementServicePlugin = new Elysia({
+  name: 'AnnouncementService',
+})
+  .use(AnnouncementRepositoryPlugin)
+  .decorate(({ announcementRepository }) => ({
+    announcementService: new AnnouncementService(announcementRepository),
+  }))

--- a/apps-api/backoffice/src/modules/announcements/services.ts
+++ b/apps-api/backoffice/src/modules/announcements/services.ts
@@ -11,6 +11,7 @@ export class AnnouncementService {
   constructor(private readonly announcementRepository: AnnouncementRepository) {}
 
   async getAnnouncements(query?: { limit: number; page: number }) {
+    // TODO: Filter by announcement type corresponding to the user role
     const announcementResult = await this.announcementRepository.getAnnouncements(query)
 
     if (announcementResult.isErr()) {
@@ -30,6 +31,7 @@ export class AnnouncementService {
   }
 
   async getAnnouncementById(id: string) {
+    // TODO: Filter by announcement type corresponding to the user role
     const announcementResult = await this.announcementRepository.getAnnouncementById(id)
 
     if (announcementResult.isErr()) {

--- a/apps-api/backoffice/src/modules/auth/index.ts
+++ b/apps-api/backoffice/src/modules/auth/index.ts
@@ -6,7 +6,7 @@ import { AuthServicePlugin } from './services'
 
 import { InternalErrorCode } from '../../dtos/error'
 import { AuthGuardPlugin } from '../../plugins/auth-guard'
-import { createErrorSchema, mapErrorCodeToResponse } from '../../utils/error'
+import { createErrorSchema, exhaustiveGuard, mapErrorCodeToResponse } from '../../utils/error'
 
 export const AuthController = new Elysia({
   adapter: node(),
@@ -63,7 +63,7 @@ export const AuthController = new Elysia({
           case InternalErrorCode.INTERNAL_SERVER_ERROR:
             return mapErrorCodeToResponse(error, status)
           default:
-            throw new Error('Unhandled error code')
+            exhaustiveGuard(error)
         }
       }
 


### PR DESCRIPTION
# Summary

- Implement get list of announcements endpoint
- Implement get announcement by id endpoint

# Screenshots/Video

<img width="1346" height="863" alt="image" src="https://github.com/user-attachments/assets/ea030a81-dab6-4ff9-8c93-935cef7b33b1" />

<img width="1291" height="584" alt="image" src="https://github.com/user-attachments/assets/7f4ad2ff-736a-4917-b657-791a8e3459cf" />

# Steps to Test

1. Visit to `http://localhost:2000/swagger` and call endpoint in `Announcement` section

# Checklist

- [x] Add Changeset
- [x] Add Linear ID in PR title
- [x] Perform Manual Testing

> [!NOTE]
