### PR TITLE
[PPLE-244] Fetch client middleware

### DIFF
--- a/.changeset/easy-readers-knock.md
+++ b/.changeset/easy-readers-knock.md
@@ -1,0 +1,5 @@
+---
+'@pple-today/api-client': patch
+---
+
+[PPLE-244] Add middleware layer to fetch query client

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -9,7 +9,14 @@ import {
 } from '@tanstack/react-query'
 import Elysia from 'elysia'
 
-import { CreateReactQueryClientResult, EdenFetch, QueryClient } from './types'
+import {
+  CreateReactQueryClientResult,
+  EdenFetch,
+  FetchClientInterceptors,
+  QueryClient,
+  RequestConfig,
+  ResponseConfig,
+} from './types'
 
 function queryKey(method: string, path: string | number | symbol, payload?: any) {
   const payloadKey = {
@@ -21,22 +28,22 @@ function queryKey(method: string, path: string | number | symbol, payload?: any)
 }
 
 function createQueryClient<TSchema extends Record<string, any>>(
-  restClient: EdenFetch.Fn<TSchema>
+  restClient: EdenFetch.Fn<TSchema> & {
+    interceptors: FetchClientInterceptors
+  }
 ): QueryClient<TSchema> {
   const makeRequest = async (method: any, path: any, payload: any) => {
-    const resp = await restClient(path, {
+    const requestConfig: any = restClient.interceptors.request({
       method,
-      params: payload?.pathParams ?? {},
+      path,
       query: payload?.query ?? {},
+      body: payload?.body ?? undefined,
       headers: payload?.headers ?? {},
-      body: payload?.body,
     })
 
-    if (resp.status >= 300) {
-      throw resp.error
-    }
+    const resp = await restClient(path, requestConfig)
 
-    return resp.data
+    return restClient.interceptors.response(resp)
   }
 
   return {
@@ -76,6 +83,19 @@ export function createReactQueryClient<T extends Elysia<any, any, any, any, any,
   options?: EdenFetch.Config
 ): CreateReactQueryClientResult<T> {
   const fetchClient: any = edenFetch<T>(server, options)
+  // Default interceptor
+  fetchClient.interceptors = {
+    request: (config: RequestConfig) => {
+      return config
+    },
+    response: (response: ResponseConfig) => {
+      if (response.status >= 400) {
+        throw response.error
+      }
+      return response.data
+    },
+  } satisfies FetchClientInterceptors
+
   const queryClient: any = createQueryClient(fetchClient)
 
   return { fetchClient, queryClient }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -18,6 +18,16 @@ import {
   ResponseConfig,
 } from './types'
 
+export type {
+  CreateReactQueryClientResult,
+  ExtractBodyRequest,
+  ExtractBodyResponse,
+  FetchClientInterceptors,
+  QueryClient,
+  RequestConfig,
+  ResponseConfig,
+} from './types'
+
 function queryKey(method: string, path: string | number | symbol, payload?: any) {
   const payloadKey = {
     pathParams: payload?.pathParams ?? {},

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -91,7 +91,7 @@ type GetPathParams<TSchema extends Record<string, any>> = TSchema extends {
     : TPathParams
   : never
 
-type RestPayload<TSchema extends Record<string, any>> = ConditionalExcept<
+export type RestPayload<TSchema extends Record<string, any>> = ConditionalExcept<
   {
     body: GetBody<TSchema>
     query: GetQuery<TSchema>
@@ -100,7 +100,7 @@ type RestPayload<TSchema extends Record<string, any>> = ConditionalExcept<
   never
 >
 
-type EdenError<
+export type EdenError<
   TSchema extends Record<string, unknown>,
   TError extends BaseEdenError<TSchema> = BaseEdenError<TSchema>,
 > =
@@ -130,15 +130,48 @@ type QueryMethod = 'get'
 type MutationMethod = 'post' | 'put' | 'patch' | 'delete'
 
 type SuccessRange = IntClosedRange<200, 299>
-type EdenSuccess<TResponse extends Record<string, unknown>> = {
+export type EdenSuccess<TResponse extends Record<string, unknown>> = {
   [K in keyof TResponse as K extends SuccessRange ? K : never]: TResponse[K]
 }
 
-type EdenResponse<TSchema extends Record<string, unknown>> = Prettify2<
+export type EdenResponse<TSchema extends Record<string, unknown>> = Prettify2<
   TSchema extends { response: infer TResponse extends Record<string, unknown> }
     ? ValueOf<EdenSuccess<TResponse>>
     : never
 >
+
+export type GetEdenFetchSchema<T extends Elysia<any, any, any, any, any, any, any>> =
+  EdenFetch.Create<T> extends EdenFetch.Fn<infer Schema> ? Schema : never
+
+export type ExtractBodyRequest<
+  TElysia extends Elysia<any, any, any, any, any, any, any>,
+  TMethod extends GetAvailableMethods<GetEdenFetchSchema<TElysia>> = GetAvailableMethods<
+    GetEdenFetchSchema<TElysia>
+  >,
+  TPath extends keyof GroupPathByMethod<
+    GetEdenFetchSchema<TElysia>,
+    TMethod
+  >[TMethod] = keyof GroupPathByMethod<GetEdenFetchSchema<TElysia>, TMethod>[TMethod],
+  TEndpoint extends GroupPathByMethod<
+    GetEdenFetchSchema<TElysia>,
+    TMethod
+  >[TMethod][TPath] = GroupPathByMethod<GetEdenFetchSchema<TElysia>, TMethod>[TMethod][TPath],
+> = GetBody<TEndpoint>
+
+export type ExtractBodyResponse<
+  TElysia extends Elysia<any, any, any, any, any, any, any>,
+  TMethod extends GetAvailableMethods<GetEdenFetchSchema<TElysia>> = GetAvailableMethods<
+    GetEdenFetchSchema<TElysia>
+  >,
+  TPath extends keyof GroupPathByMethod<
+    GetEdenFetchSchema<TElysia>,
+    TMethod
+  >[TMethod] = keyof GroupPathByMethod<GetEdenFetchSchema<TElysia>, TMethod>[TMethod],
+  TEndpoint extends GroupPathByMethod<
+    GetEdenFetchSchema<TElysia>,
+    TMethod
+  >[TMethod][TPath] = GroupPathByMethod<GetEdenFetchSchema<TElysia>, TMethod>[TMethod][TPath],
+> = EdenResponse<TEndpoint>
 
 export interface QueryClient<
   TPathSchema extends Record<string, any>,
@@ -243,6 +276,6 @@ export interface CreateReactQueryClientResult<T extends Elysia<any, any, any, an
   fetchClient: EdenFetch.Create<T> & {
     interceptors: FetchClientInterceptors
   }
-  queryClient: EdenFetch.Create<T> extends EdenFetch.Fn<infer Schema> ? QueryClient<Schema> : never
+  queryClient: QueryClient<GetEdenFetchSchema<T>>
 }
 export { type EdenFetch }

--- a/packages/api-client/src/types.ts
+++ b/packages/api-client/src/types.ts
@@ -212,8 +212,37 @@ export interface QueryClient<
   ) => UseMutationOptions<TSuccess, TError, TPayload, TContext>
 }
 
+export interface RequestConfig {
+  method: string
+  path: string
+  query?: Record<string, any>
+  body?: any
+  headers?: Record<string, string>
+}
+
+export type ResponseConfig =
+  | {
+      data: any
+      error: null
+      headers: Record<string, unknown>
+      status: number
+    }
+  | {
+      data: null
+      error: any
+      headers: Record<string, unknown>
+      status: number
+    }
+
+export interface FetchClientInterceptors {
+  request: (config: RequestConfig) => RequestConfig
+  response: (response: ResponseConfig) => any
+}
+
 export interface CreateReactQueryClientResult<T extends Elysia<any, any, any, any, any, any, any>> {
-  fetchClient: EdenFetch.Create<T>
+  fetchClient: EdenFetch.Create<T> & {
+    interceptors: FetchClientInterceptors
+  }
   queryClient: EdenFetch.Create<T> extends EdenFetch.Fn<infer Schema> ? QueryClient<Schema> : never
 }
 export { type EdenFetch }


### PR DESCRIPTION
# Summary

- Add onRequest and onResponse interceptor in fetch client middleware

# Screenshots/Video

<img width="514" height="149" alt="image" src="https://github.com/user-attachments/assets/e091531c-7218-46f8-adb6-362ccb6d5aae" />

<img width="971" height="165" alt="image" src="https://github.com/user-attachments/assets/e57aefbd-90e3-4a67-a37c-7d4091dac3ae" />

# Steps to Test

1. Inject onRequest method via `fetchClient.interceptors.request`
2. Attempt to make request from mobile

# Checklist

- [x] Add Changeset
- [x] Add Linear ID in PR title
- [x] Perform Manual Testing

> [!NOTE]
