### PR TITLE
[PPLE-214] Announcement Card

### DIFF
--- a/.changeset/tidy-crabs-prove.md
+++ b/.changeset/tidy-crabs-prove.md
@@ -1,0 +1,7 @@
+---
+"@client/mobile": minor
+"expo-scroll-forwarder": patch
+"@pple-today/ui": patch
+---
+
+[[PPLE-214] Announcement Card](https://linear.app/snts/issue/PPLE-214/announcement-card)

--- a/apps-client/mobile/app/(tabs)/index.tsx
+++ b/apps-client/mobile/app/(tabs)/index.tsx
@@ -35,12 +35,7 @@ import Animated, {
 import { Badge } from '@pple-today/ui/badge'
 import { Button } from '@pple-today/ui/button'
 import { Icon } from '@pple-today/ui/icon'
-import {
-  Carousel,
-  CarouselIndicators,
-  CarouselItem,
-  CarouselScrollView,
-} from '@pple-today/ui/slide'
+import { Slide, SlideIndicators, SlideItem, SlideScrollView } from '@pple-today/ui/slide'
 import { Text } from '@pple-today/ui/text'
 import { H2, H3 } from '@pple-today/ui/typography'
 import { Image } from 'expo-image'
@@ -136,22 +131,22 @@ interface BannerItem {
 
 function BannerSection() {
   return (
-    <Carousel
+    <Slide
       count={BANNER_ITEMS.length}
       itemWidth={320}
       gap={8}
       paddingHorizontal={16}
       className="w-full pt-2 py-4"
     >
-      <CarouselScrollView>
+      <SlideScrollView>
         {BANNER_ITEMS.map((item) => (
-          <CarouselItem key={item.id} className="bg-base-bg-light rounded-xl overflow-hidden">
+          <SlideItem key={item.id} className="bg-base-bg-light rounded-xl overflow-hidden">
             <Banner item={item} />
-          </CarouselItem>
+          </SlideItem>
         ))}
-      </CarouselScrollView>
-      <CarouselIndicators />
-    </Carousel>
+      </SlideScrollView>
+      <SlideIndicators />
+    </Slide>
   )
 }
 

--- a/apps-client/mobile/components/announcement.tsx
+++ b/apps-client/mobile/components/announcement.tsx
@@ -4,12 +4,7 @@ import { View } from 'react-native'
 
 import { Badge } from '@pple-today/ui/badge'
 import { cn } from '@pple-today/ui/lib/utils'
-import {
-  Carousel,
-  CarouselIndicators,
-  CarouselItem,
-  CarouselScrollView,
-} from '@pple-today/ui/slide'
+import { Slide, SlideIndicators, SlideItem, SlideScrollView } from '@pple-today/ui/slide'
 import { Text } from '@pple-today/ui/text'
 import dayjs from 'dayjs'
 import buddhistEra from 'dayjs/plugin/buddhistEra'
@@ -49,16 +44,16 @@ const ANNOUNCEMENTS: Announcement[] = [
 
 export function AnnouncementSlides() {
   return (
-    <Carousel count={ANNOUNCEMENTS.length} itemWidth={320} gap={8} paddingHorizontal={16}>
-      <CarouselScrollView>
+    <Slide count={ANNOUNCEMENTS.length} itemWidth={320} gap={8} paddingHorizontal={16}>
+      <SlideScrollView>
         {ANNOUNCEMENTS.map((item) => (
-          <CarouselItem key={item.id}>
+          <SlideItem key={item.id}>
             <AnnouncementCard item={item} />
-          </CarouselItem>
+          </SlideItem>
         ))}
-      </CarouselScrollView>
-      <CarouselIndicators />
-    </Carousel>
+      </SlideScrollView>
+      <SlideIndicators />
+    </Slide>
   )
 }
 

--- a/apps-client/mobile/components/announcement.tsx
+++ b/apps-client/mobile/components/announcement.tsx
@@ -1,0 +1,102 @@
+import 'dayjs/locale/th'
+
+import { View } from 'react-native'
+
+import { Badge } from '@pple-today/ui/badge'
+import { cn } from '@pple-today/ui/lib/utils'
+import {
+  Carousel,
+  CarouselIndicators,
+  CarouselItem,
+  CarouselScrollView,
+} from '@pple-today/ui/slide'
+import { Text } from '@pple-today/ui/text'
+import dayjs from 'dayjs'
+import buddhistEra from 'dayjs/plugin/buddhistEra'
+
+import PPLEIcon from '@app/assets/pple-icon.svg'
+
+dayjs.extend(buddhistEra)
+dayjs.locale('th')
+
+interface Announcement {
+  id: string
+  title: string
+  topics: string[]
+  date: string
+}
+const ANNOUNCEMENTS: Announcement[] = [
+  {
+    id: '1',
+    title: 'ประชุมเลือกตั้งตัวแทนพรรคประจำ อำเภอ(ตทอ.) ประจำอำเภอเมืองสมุทรปราการ',
+    topics: ['#เลือกตั้ง'],
+    date: '2023-01-01',
+  },
+  {
+    id: '2',
+    title:
+      'Lorem ipsum dolor sit amet consectetur adipisicing elit. Saepe cupiditate excepturi inventore, ipsa ipsam recusandae consequatur amet ab iusto, voluptatum, sapiente officia! Iste maiores voluptates perferendis doloremque. Voluptatum, excepturi accusamus officiis magni doloribus minus nesciunt veritatis exercitationem ab earum soluta enim voluptatem in architecto doloremque minima non vero error aspernatur?',
+    topics: ['Topic 2'],
+    date: '2023-01-02',
+  },
+  {
+    id: '3',
+    title: 'Announcement 3',
+    topics: ['Topic 3'],
+    date: '2023-01-03',
+  },
+]
+
+export function AnnouncementSlides() {
+  return (
+    <Carousel count={ANNOUNCEMENTS.length} itemWidth={320} gap={8} paddingHorizontal={16}>
+      <CarouselScrollView>
+        {ANNOUNCEMENTS.map((item) => (
+          <CarouselItem key={item.id}>
+            <AnnouncementCard item={item} />
+          </CarouselItem>
+        ))}
+      </CarouselScrollView>
+      <CarouselIndicators />
+    </Carousel>
+  )
+}
+
+interface AnnouncementCardProps {
+  item: Announcement
+  className?: string
+}
+export function AnnouncementCard(props: AnnouncementCardProps) {
+  return (
+    <View
+      className={cn(
+        'w-[320px] h-[120px] border border-base-outline-default bg-base-bg-white rounded-2xl flex flex-row gap-4 items-center px-3 py-4',
+        props.className
+      )}
+    >
+      {/* TODO: Logo */}
+      <View className="w-[80px] h-[80px] bg-primary-500 rounded-xl flex flex-row items-center justify-center">
+        <View className="w-[48px] h-[48px] rounded-full bg-primary-800 flex flex-row items-center justify-center">
+          <PPLEIcon width={24} height={20} color="white" />
+        </View>
+      </View>
+      <View className="flex flex-col justify-between flex-1">
+        <Text className="text-base-text-high font-anakotmai-medium text-sm line-clamp-3 flex-1">
+          {props.item.title}
+        </Text>
+        <View className="flex flex-row gap-1 justify-between items-center">
+          <View className="flex flex-row flex-wrap gap-1">
+            {props.item.topics.map((topic, index) => (
+              <Badge key={index} variant="secondary">
+                <Text>{topic}</Text>
+              </Badge>
+            ))}
+          </View>
+          <Text className="font-anakotmai-light text-xs text-base-text-medium">
+            {dayjs(props.item.date).format('DD MMM BB')}
+          </Text>
+        </View>
+      </View>
+    </View>
+  )
+}

--- a/apps-client/mobile/package.json
+++ b/apps-client/mobile/package.json
@@ -35,6 +35,7 @@
     "@react-navigation/native": "^7.1.6",
     "@tanstack/react-form": "^1.14.1",
     "@tanstack/react-query": "^5.81.5",
+    "dayjs": "^1.11.13",
     "expo": "~53.0.12",
     "expo-auth-session": "^6.2.0",
     "expo-blur": "~14.1.4",

--- a/packages/expo-scroll-forwarder/android/src/main/java/expo/modules/scrollforwarder/ExpoScrollForwarderView.kt
+++ b/packages/expo-scroll-forwarder/android/src/main/java/expo/modules/scrollforwarder/ExpoScrollForwarderView.kt
@@ -35,6 +35,11 @@ class ExpoScrollForwarderView(context: Context, appContext: AppContext) :
             return
         }
         scrollView = rootView.findViewById<View>(scrollViewTag)
+        if (scrollView == null) {
+            Log.d(TAG, "ScrollView $scrollViewTag is not found")
+        } else {
+            Log.d(TAG, "ScrollView $scrollViewTag is found")
+        }
     }
     override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
         super.onLayout(changed, l, t, r, b)

--- a/packages/expo-scroll-forwarder/android/src/main/java/expo/modules/scrollforwarder/ExpoScrollForwarderView.kt
+++ b/packages/expo-scroll-forwarder/android/src/main/java/expo/modules/scrollforwarder/ExpoScrollForwarderView.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewConfiguration
+import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.views.ExpoView
@@ -42,6 +43,14 @@ class ExpoScrollForwarderView(context: Context, appContext: AppContext) :
         }
     }
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        if (scrollViewTag != null && scrollView == null) {
+            // sometimes tryFindScrollView does not work on first layout, try it again here
+            tryFindScrollView()
+            if (scrollView == null) {
+                // if we still can't find it by the time user touches, give up
+                scrollViewTag = null
+            }
+        }
         val scrollView = this.scrollView
         if (scrollView == null) {
             return super.dispatchTouchEvent(ev)

--- a/packages/ui/src/components/ui/slide.tsx
+++ b/packages/ui/src/components/ui/slide.tsx
@@ -92,15 +92,21 @@ export function SlideIndicator({ index }: { index: number }) {
       }
       return i * itemWidthWithGap
     }
-
     const snapRange = [getSnapPoint(index - 1), getSnapPoint(index), getSnapPoint(index + 1)]
-    const inputRange = [-1, 0, 1]
-    const input = interpolate(scroll.value, snapRange, inputRange, 'clamp')
-    const width = interpolate(input, inputRange, [6, 24, 6])
-    const color = interpolateColor(input, inputRange, ['#CBD5E1', '#FF6A13', '#CBD5E1'])
+    const widthRange = [6, 24, 6]
+    const colorRange = ['#CBD5E1', '#FF6A13', '#CBD5E1']
+    if (index === 0) {
+      snapRange.shift()
+      widthRange.shift()
+      colorRange.shift()
+    } else if (index === count - 1) {
+      snapRange.pop()
+      widthRange.pop()
+      colorRange.pop()
+    }
     return {
-      width: width,
-      backgroundColor: color,
+      width: interpolate(scroll.value, snapRange, widthRange, 'clamp'),
+      backgroundColor: interpolateColor(scroll.value, snapRange, colorRange),
     }
   })
   return <Animated.View style={animatedStyle} className="h-1.5 rounded-full" />

--- a/packages/ui/src/components/ui/slide.tsx
+++ b/packages/ui/src/components/ui/slide.tsx
@@ -12,7 +12,7 @@ import Animated, {
 
 import { cn } from '../../lib/utils'
 
-interface CarouselContextValue {
+interface SlideContextValue {
   gap: number
   count: number
   itemWidth: number
@@ -23,16 +23,16 @@ interface CarouselContextValue {
   setScrollViewWidth: React.Dispatch<React.SetStateAction<number>>
   paddingHorizontal: number
 }
-const CarouselContext = React.createContext<CarouselContextValue | null>(null)
-const CarouselProvider = CarouselContext.Provider
-const useCarouselContext = () => {
-  const context = React.useContext(CarouselContext)
+const SlideContext = React.createContext<SlideContextValue | null>(null)
+const SlideProvider = SlideContext.Provider
+const useSlideContext = () => {
+  const context = React.useContext(SlideContext)
   if (!context) {
-    throw new Error('useCarouselContext must be used within a CarouselProvider')
+    throw new Error('useSlideContext must be used within a SlideProvider')
   }
   return context
 }
-export function Carousel({
+export function Slide({
   gap,
   count,
   itemWidth,
@@ -51,7 +51,7 @@ export function Carousel({
   const [scrollViewWidth, setScrollViewWidth] = React.useState(0)
   const scroll = useSharedValue(0)
   return (
-    <CarouselProvider
+    <SlideProvider
       value={{
         gap,
         count,
@@ -65,25 +65,25 @@ export function Carousel({
       }}
     >
       <View className={cn('w-full flex flex-col gap-4', className)}>{children}</View>
-    </CarouselProvider>
+    </SlideProvider>
   )
 }
 
-export function CarouselIndicators() {
-  const { count } = useCarouselContext()
+export function SlideIndicators() {
+  const { count } = useSlideContext()
   // TODO: calculate number of indicators based on the number of items and width of the carousel
   // number of indicators might not equal the number of images since in large screen it might show more than one item
   return (
     <View className="flex flex-row items-center justify-center gap-1">
       {Array.from({ length: count }).map((_, index) => (
-        <CarouselIndicator key={index} index={index} />
+        <SlideIndicator key={index} index={index} />
       ))}
     </View>
   )
 }
 
-export function CarouselIndicator({ index }: { index: number }) {
-  const { scroll, itemWidth, count, scrollViewWidth, gap, paddingHorizontal } = useCarouselContext()
+export function SlideIndicator({ index }: { index: number }) {
+  const { scroll, itemWidth, count, scrollViewWidth, gap, paddingHorizontal } = useSlideContext()
   const animatedStyle = useAnimatedStyle(() => {
     const itemWidthWithGap = itemWidth + gap
     const getSnapPoint = (i: number) => {
@@ -107,7 +107,7 @@ export function CarouselIndicator({ index }: { index: number }) {
 }
 
 const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView)
-export function CarouselScrollView(props: { children: React.ReactNode }) {
+export function SlideScrollView(props: { children: React.ReactNode }) {
   const {
     gap,
     itemWidth,
@@ -116,7 +116,7 @@ export function CarouselScrollView(props: { children: React.ReactNode }) {
     scroll,
     setScrollViewWidth,
     paddingHorizontal,
-  } = useCarouselContext()
+  } = useSlideContext()
   const onScrollWorklet = React.useCallback(
     (event: NativeScrollEvent) => {
       'worklet'
@@ -150,8 +150,8 @@ export function CarouselScrollView(props: { children: React.ReactNode }) {
   )
 }
 
-export function CarouselItem(props: { className?: string; children: React.ReactNode }) {
-  const { itemWidth } = useCarouselContext()
+export function SlideItem(props: { className?: string; children: React.ReactNode }) {
+  const { itemWidth } = useSlideContext()
   return (
     <View style={{ width: itemWidth }} className={props.className}>
       {props.children}

--- a/packages/ui/src/components/ui/slide.tsx
+++ b/packages/ui/src/components/ui/slide.tsx
@@ -1,0 +1,160 @@
+import * as React from 'react'
+import { NativeScrollEvent, ScrollView, View } from 'react-native'
+import Animated, {
+  interpolate,
+  interpolateColor,
+  runOnJS,
+  SharedValue,
+  useAnimatedScrollHandler,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated'
+
+import { cn } from '../../lib/utils'
+
+interface CarouselContextValue {
+  gap: number
+  count: number
+  itemWidth: number
+  currentPage: number
+  setCurrentPage: React.Dispatch<React.SetStateAction<number>>
+  scroll: SharedValue<number>
+  scrollViewWidth: number
+  setScrollViewWidth: React.Dispatch<React.SetStateAction<number>>
+  paddingHorizontal: number
+}
+const CarouselContext = React.createContext<CarouselContextValue | null>(null)
+const CarouselProvider = CarouselContext.Provider
+const useCarouselContext = () => {
+  const context = React.useContext(CarouselContext)
+  if (!context) {
+    throw new Error('useCarouselContext must be used within a CarouselProvider')
+  }
+  return context
+}
+export function Carousel({
+  gap,
+  count,
+  itemWidth,
+  children,
+  paddingHorizontal,
+  className,
+}: {
+  gap: number
+  count: number
+  itemWidth: number
+  children: React.ReactNode
+  paddingHorizontal: number
+  className?: string
+}) {
+  const [currentPage, setCurrentPage] = React.useState(0)
+  const [scrollViewWidth, setScrollViewWidth] = React.useState(0)
+  const scroll = useSharedValue(0)
+  return (
+    <CarouselProvider
+      value={{
+        gap,
+        count,
+        itemWidth,
+        currentPage,
+        setCurrentPage,
+        scroll,
+        scrollViewWidth,
+        setScrollViewWidth,
+        paddingHorizontal,
+      }}
+    >
+      <View className={cn('w-full flex flex-col gap-4', className)}>{children}</View>
+    </CarouselProvider>
+  )
+}
+
+export function CarouselIndicators() {
+  const { count } = useCarouselContext()
+  // TODO: calculate number of indicators based on the number of items and width of the carousel
+  // number of indicators might not equal the number of images since in large screen it might show more than one item
+  return (
+    <View className="flex flex-row items-center justify-center gap-1">
+      {Array.from({ length: count }).map((_, index) => (
+        <CarouselIndicator key={index} index={index} />
+      ))}
+    </View>
+  )
+}
+
+export function CarouselIndicator({ index }: { index: number }) {
+  const { scroll, itemWidth, count, scrollViewWidth, gap, paddingHorizontal } = useCarouselContext()
+  const animatedStyle = useAnimatedStyle(() => {
+    const itemWidthWithGap = itemWidth + gap
+    const getSnapPoint = (i: number) => {
+      if (i === count - 1) {
+        return i * itemWidthWithGap - (scrollViewWidth - paddingHorizontal * 2 - itemWidth - gap)
+      }
+      return i * itemWidthWithGap
+    }
+
+    const snapRange = [getSnapPoint(index - 1), getSnapPoint(index), getSnapPoint(index + 1)]
+    const inputRange = [-1, 0, 1]
+    const input = interpolate(scroll.value, snapRange, inputRange, 'clamp')
+    const width = interpolate(input, inputRange, [6, 24, 6])
+    const color = interpolateColor(input, inputRange, ['#CBD5E1', '#FF6A13', '#CBD5E1'])
+    return {
+      width: width,
+      backgroundColor: color,
+    }
+  })
+  return <Animated.View style={animatedStyle} className="h-1.5 rounded-full" />
+}
+
+const AnimatedScrollView = Animated.createAnimatedComponent(ScrollView)
+export function CarouselScrollView(props: { children: React.ReactNode }) {
+  const {
+    gap,
+    itemWidth,
+    currentPage,
+    setCurrentPage,
+    scroll,
+    setScrollViewWidth,
+    paddingHorizontal,
+  } = useCarouselContext()
+  const onScrollWorklet = React.useCallback(
+    (event: NativeScrollEvent) => {
+      'worklet'
+      scroll.set(event.contentOffset.x)
+      const current = Math.max(0, Math.round(event.contentOffset.x / itemWidth))
+      if (currentPage !== current) {
+        runOnJS(setCurrentPage)(current)
+      }
+    },
+    [setCurrentPage, currentPage, itemWidth, scroll]
+  )
+  const scrollHandler = useAnimatedScrollHandler({
+    onScroll: onScrollWorklet,
+  })
+  return (
+    <AnimatedScrollView
+      onScroll={scrollHandler}
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      className="w-full"
+      contentContainerStyle={{ gap, paddingHorizontal }}
+      pagingEnabled
+      snapToInterval={itemWidth + gap}
+      // disableIntervalMomentum
+      onLayout={(e) => {
+        setScrollViewWidth(e.nativeEvent.layout.width)
+      }}
+    >
+      {props.children}
+    </AnimatedScrollView>
+  )
+}
+
+export function CarouselItem(props: { className?: string; children: React.ReactNode }) {
+  const { itemWidth } = useCarouselContext()
+  return (
+    <View style={{ width: itemWidth }} className={props.className}>
+      {props.children}
+    </View>
+  )
+}

--- a/packages/ui/src/components/ui/slide.tsx
+++ b/packages/ui/src/components/ui/slide.tsx
@@ -140,7 +140,7 @@ export function CarouselScrollView(props: { children: React.ReactNode }) {
       contentContainerStyle={{ gap, paddingHorizontal }}
       pagingEnabled
       snapToInterval={itemWidth + gap}
-      // disableIntervalMomentum
+      disableIntervalMomentum
       onLayout={(e) => {
         setScrollViewWidth(e.nativeEvent.layout.width)
       }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.81.5
         version: 5.81.5(react@19.0.0)
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       expo:
         specifier: ~53.0.12
         version: 53.0.18(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.79.4(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0)))(react-native-webview@13.13.5(react-native@0.79.4(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0))(react-native@0.79.4(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.0.14)(react@19.0.0))(react@19.0.0)
@@ -3326,6 +3329,9 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
 
   '@svgr/core@8.1.0':
     resolution: {integrity: sha512-8QqtOQT5ACVlmsvKOJNEaWmRPmcojMOzCz4Hs2BGG/toAp/K38LcsMRyLp349glq5AzJbCEeimEoxaX6v/fLrA==}
@@ -12969,7 +12975,6 @@ snapshots:
 
   '@svgr/babel-preset@8.1.0(@babel/core@7.27.1)':
     dependencies:
-      '@babel/core': 7.27.1
       '@svgr/babel-plugin-add-jsx-attribute': 8.0.0(@babel/core@7.27.1)
       '@svgr/babel-plugin-remove-jsx-attribute': 8.0.0(@babel/core@7.27.1)
       '@svgr/babel-plugin-remove-jsx-empty-expression': 8.0.0(@babel/core@7.27.1)
@@ -12978,6 +12983,8 @@ snapshots:
       '@svgr/babel-plugin-svg-em-dimensions': 8.0.0(@babel/core@7.27.1)
       '@svgr/babel-plugin-transform-react-native-svg': 8.1.0(@babel/core@7.27.1)
       '@svgr/babel-plugin-transform-svg-component': 8.0.0(@babel/core@7.27.1)
+    optionalDependencies:
+      '@babel/core': 7.27.1
 
   '@svgr/core@8.1.0(typescript@5.8.3)':
     dependencies:
@@ -14526,8 +14533,7 @@ snapshots:
 
   dateformat@4.6.3: {}
 
-  dayjs@1.11.13:
-    optional: true
+  dayjs@1.11.13: {}
 
   debug@2.6.9:
     dependencies:
@@ -14976,7 +14982,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -15020,7 +15026,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.26.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.26.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.31.0(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
# Summary

- Implemented AnnouncementCard UI only
- Refactor PagerView with Header to be composable
- Rename `Carousel` to `Slide` because it doesn't really rotate (to preserve the name `Carousel` for possibly the library [react-native-snap-carousel](https://github.com/meliorence/react-native-snap-carousel) in the future)
- Since`ExpoScrollForwarder` on Android works differently from iOS's UIGestureRecognizer, I decided to compose it differently \
The ScrollForwarder on android will be only on top of the header only but on iOS it will be the parent since UIGestureRecognizer can only be on 1 View.
- Fix `SlideIndicator` to not shrink when exceed input range

- Don't forget to review `apps-client/mobile/app/(tabs)/index.tsx` since it's a large file

# Screenshots/Video

https://github.com/user-attachments/assets/cddc9679-b762-49a4-b572-23cdba928034

https://github.com/user-attachments/assets/6115c8b4-13c3-483c-ab81-e26009cfd0c9

# Checklist

- [x] Add Changeset
- [x] Add Linear ID in PR title
- [x] Perform Manual Testing

> [!NOTE]
> Note that on android, you need to scroll slowly or else it will interfere with the PagerView