### PR TITLE
[PPLE-247] OIDC redirect causes dismiss in android

### DIFF
--- a/.changeset/cold-carpets-shine.md
+++ b/.changeset/cold-carpets-shine.md
@@ -2,4 +2,4 @@
 '@client/mobile': patch
 ---
 
-[PPLE-247] OIDC redirect not working in android
+[[PPLE-247] OIDC redirect not working in android](https://linear.app/snts/issue/PPLE-247/oidc-redirect-not-working-in-android)

--- a/.changeset/cold-carpets-shine.md
+++ b/.changeset/cold-carpets-shine.md
@@ -1,0 +1,5 @@
+---
+'@client/mobile': patch
+---
+
+[PPLE-247] OIDC redirect not working in android

--- a/apps-client/mobile/libs/auth.ts
+++ b/apps-client/mobile/libs/auth.ts
@@ -26,8 +26,7 @@ const authRequest: AuthRequest = new AuthRequest({
   scopes: ['openid', 'profile', 'phone'],
   codeChallengeMethod: CodeChallengeMethod.S256,
   redirectUri: makeRedirectUri({
-    scheme: appConfig.expo.scheme,
-    isTripleSlashed: true,
+    native: `${appConfig.expo.scheme}:/`,
   }),
 })
 
@@ -129,7 +128,7 @@ export const login = async ({ discovery }: { discovery: DiscoveryDocument }) => 
     // open in-app browser to login flow in PPLE SSO
     loginResult = await authRequest.promptAsync(discovery, {
       browserPackage,
-      // preferEphemeralSession: true, // Uncomment to test in incognito mode
+      showInRecents: true,
     })
   } catch (error) {
     console.error('Error during authentication prompt:', error)


### PR DESCRIPTION
# Summary

- Fix OIDC redirect causes dismiss in android 

# Screenshots/Video

# Steps to Test

1. Please login via SSO in android
2. After successfully login, application should get accessToken from SSO

# Checklist

- [x] Add Changeset
- [x] Add Linear ID in PR title
- [x] Perform Manual Testing

> [!NOTE]
