### PR TITLE
[PPLE - 254] api get address filtering

### DIFF
--- a/apps-api/backoffice/src/modules/address/index.ts
+++ b/apps-api/backoffice/src/modules/address/index.ts
@@ -8,28 +8,43 @@ import {
   GetSubDistinctQuery,
   GetSubDistinctResponse,
 } from './model'
+import { AddressServicePlugin } from './service'
+import { createErrorSchema, mapErrorCodeToResponse } from '../../utils/error'
+import { InternalErrorCode } from '../../dtos/error'
 
 export const AddressController = new Elysia({
   prefix: '/address',
   tags: ['Address'],
 })
+  .use(AddressServicePlugin)
   .get(
     '/province',
-    () => {
-      return []
+    async ({ addressService, status }) => {
+      const provinces = await addressService.getProvinces()
+
+      if (provinces.isErr()) {
+        return mapErrorCodeToResponse(provinces.error, status)
+      }
+
+      return status(200, provinces.value)
     },
     {
-      response: GetProvinceResponse,
+      response: {
+        200: GetProvinceResponse,
+        ...createErrorSchema(InternalErrorCode.INTERNAL_SERVER_ERROR),
+      },
     }
   )
   .get(
     '/distinct',
-    () => {
+    async () => {
       return []
     },
     {
       query: GetDistinctQuery,
-      response: GetDistinctResponse,
+      response: {
+        200: GetDistinctResponse,
+      },
     }
   )
   .get(
@@ -39,7 +54,9 @@ export const AddressController = new Elysia({
     },
     {
       query: GetSubDistinctQuery,
-      response: GetSubDistinctResponse,
+      response: {
+        200: GetSubDistinctResponse,
+      },
     }
   )
   .get(
@@ -49,6 +66,8 @@ export const AddressController = new Elysia({
     },
     {
       query: GetPostalCodeQuery,
-      response: GetPostalCodeResponse,
+      response: {
+        200: GetPostalCodeResponse,
+      },
     }
   )

--- a/apps-api/backoffice/src/modules/address/index.ts
+++ b/apps-api/backoffice/src/modules/address/index.ts
@@ -1,0 +1,54 @@
+import Elysia from 'elysia'
+import {
+  GetDistinctQuery,
+  GetDistinctResponse,
+  GetPostalCodeQuery,
+  GetPostalCodeResponse,
+  GetProvinceResponse,
+  GetSubDistinctQuery,
+  GetSubDistinctResponse,
+} from './model'
+
+export const AddressController = new Elysia({
+  prefix: '/address',
+  tags: ['Address'],
+})
+  .get(
+    '/province',
+    () => {
+      return []
+    },
+    {
+      response: GetProvinceResponse,
+    }
+  )
+  .get(
+    '/distinct',
+    () => {
+      return []
+    },
+    {
+      query: GetDistinctQuery,
+      response: GetDistinctResponse,
+    }
+  )
+  .get(
+    '/subdistinct',
+    () => {
+      return []
+    },
+    {
+      query: GetSubDistinctQuery,
+      response: GetSubDistinctResponse,
+    }
+  )
+  .get(
+    '/postal-code',
+    () => {
+      return []
+    },
+    {
+      query: GetPostalCodeQuery,
+      response: GetPostalCodeResponse,
+    }
+  )

--- a/apps-api/backoffice/src/modules/address/index.ts
+++ b/apps-api/backoffice/src/modules/address/index.ts
@@ -56,13 +56,20 @@ export const AddressController = new Elysia({
   )
   .get(
     '/subdistinct',
-    () => {
-      return []
+    async ({ addressService, status, query }) => {
+      const subDistricts = await addressService.getSubDistricts(query.distinct)
+
+      if (subDistricts.isErr()) {
+        return mapErrorCodeToResponse(subDistricts.error, status)
+      }
+
+      return status(200, subDistricts.value)
     },
     {
       query: GetSubDistrictQuery,
       response: {
         200: GetSubDistrictResponse,
+        ...createErrorSchema(InternalErrorCode.INTERNAL_SERVER_ERROR),
       },
     }
   )

--- a/apps-api/backoffice/src/modules/address/index.ts
+++ b/apps-api/backoffice/src/modules/address/index.ts
@@ -1,12 +1,12 @@
 import Elysia from 'elysia'
 import {
-  GetDistinctQuery,
-  GetDistinctResponse,
+  GetDistrictQuery,
+  GetDistrictResponse,
   GetPostalCodeQuery,
   GetPostalCodeResponse,
   GetProvinceResponse,
-  GetSubDistinctQuery,
-  GetSubDistinctResponse,
+  GetSubDistrictQuery,
+  GetSubDistrictResponse,
 } from './model'
 import { AddressServicePlugin } from './service'
 import { createErrorSchema, mapErrorCodeToResponse } from '../../utils/error'
@@ -36,14 +36,21 @@ export const AddressController = new Elysia({
     }
   )
   .get(
-    '/distinct',
-    async () => {
-      return []
+    '/district',
+    async ({ query, addressService, status }) => {
+      const districts = await addressService.getDistricts(query.province)
+
+      if (districts.isErr()) {
+        return mapErrorCodeToResponse(districts.error, status)
+      }
+
+      return status(200, districts.value)
     },
     {
-      query: GetDistinctQuery,
+      query: GetDistrictQuery,
       response: {
-        200: GetDistinctResponse,
+        200: GetDistrictResponse,
+        ...createErrorSchema(InternalErrorCode.INTERNAL_SERVER_ERROR),
       },
     }
   )
@@ -53,9 +60,9 @@ export const AddressController = new Elysia({
       return []
     },
     {
-      query: GetSubDistinctQuery,
+      query: GetSubDistrictQuery,
       response: {
-        200: GetSubDistinctResponse,
+        200: GetSubDistrictResponse,
       },
     }
   )

--- a/apps-api/backoffice/src/modules/address/index.ts
+++ b/apps-api/backoffice/src/modules/address/index.ts
@@ -75,13 +75,20 @@ export const AddressController = new Elysia({
   )
   .get(
     '/postal-code',
-    () => {
-      return []
+    async ({ addressService, status, query }) => {
+      const postalCodes = await addressService.getPostalCodes(query.subdistrict)
+
+      if (postalCodes.isErr()) {
+        return mapErrorCodeToResponse(postalCodes.error, status)
+      }
+
+      return status(200, postalCodes.value)
     },
     {
       query: GetPostalCodeQuery,
       response: {
         200: GetPostalCodeResponse,
+        ...createErrorSchema(InternalErrorCode.INTERNAL_SERVER_ERROR),
       },
     }
   )

--- a/apps-api/backoffice/src/modules/address/model.ts
+++ b/apps-api/backoffice/src/modules/address/model.ts
@@ -1,0 +1,18 @@
+import { t } from 'elysia'
+
+export const GetProvinceResponse = t.Array(t.String())
+
+export const GetDistinctQuery = t.Object({
+  province: t.Optional(t.String()),
+})
+export const GetDistinctResponse = t.Array(t.String())
+
+export const GetSubDistinctQuery = t.Object({
+  distinct: t.Optional(t.String()),
+})
+export const GetSubDistinctResponse = t.Array(t.String())
+
+export const GetPostalCodeQuery = t.Object({
+  subdistinct: t.Optional(t.String()),
+})
+export const GetPostalCodeResponse = t.Array(t.String())

--- a/apps-api/backoffice/src/modules/address/model.ts
+++ b/apps-api/backoffice/src/modules/address/model.ts
@@ -13,6 +13,6 @@ export const GetSubDistrictQuery = t.Object({
 export const GetSubDistrictResponse = t.Array(t.String())
 
 export const GetPostalCodeQuery = t.Object({
-  subdistinct: t.Optional(t.String()),
+  subdistrict: t.Optional(t.String()),
 })
 export const GetPostalCodeResponse = t.Array(t.String())

--- a/apps-api/backoffice/src/modules/address/model.ts
+++ b/apps-api/backoffice/src/modules/address/model.ts
@@ -2,15 +2,15 @@ import { t } from 'elysia'
 
 export const GetProvinceResponse = t.Array(t.String())
 
-export const GetDistinctQuery = t.Object({
+export const GetDistrictQuery = t.Object({
   province: t.Optional(t.String()),
 })
-export const GetDistinctResponse = t.Array(t.String())
+export const GetDistrictResponse = t.Array(t.String())
 
-export const GetSubDistinctQuery = t.Object({
+export const GetSubDistrictQuery = t.Object({
   distinct: t.Optional(t.String()),
 })
-export const GetSubDistinctResponse = t.Array(t.String())
+export const GetSubDistrictResponse = t.Array(t.String())
 
 export const GetPostalCodeQuery = t.Object({
   subdistinct: t.Optional(t.String()),

--- a/apps-api/backoffice/src/modules/address/repository.ts
+++ b/apps-api/backoffice/src/modules/address/repository.ts
@@ -5,12 +5,13 @@ import { fromPrismaPromise } from '../../utils/prisma'
 export class AddressRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async getAddresses(options?: { province?: string; district?: string }) {
+  async getAddresses(options?: { province?: string; district?: string; subDistrict?: string }) {
     return fromPrismaPromise(
       this.prismaService.address.findMany({
         where: {
           province: options?.province === undefined ? {} : { equals: options.province },
           district: options?.district === undefined ? {} : { equals: options.district },
+          subDistrict: options?.subDistrict === undefined ? {} : { equals: options.subDistrict },
         },
         orderBy: [
           { province: 'asc' },

--- a/apps-api/backoffice/src/modules/address/repository.ts
+++ b/apps-api/backoffice/src/modules/address/repository.ts
@@ -5,13 +5,13 @@ import { fromPrismaPromise } from '../../utils/prisma'
 export class AddressRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async getAddresses(options?: { province?: string; district?: string; subDistrict?: string }) {
+  async getAddresses(filter?: { province?: string; district?: string; subDistrict?: string }) {
     return fromPrismaPromise(
       this.prismaService.address.findMany({
         where: {
-          province: options?.province === undefined ? {} : { equals: options.province },
-          district: options?.district === undefined ? {} : { equals: options.district },
-          subDistrict: options?.subDistrict === undefined ? {} : { equals: options.subDistrict },
+          province: filter?.province === undefined ? {} : { equals: filter.province },
+          district: filter?.district === undefined ? {} : { equals: filter.district },
+          subDistrict: filter?.subDistrict === undefined ? {} : { equals: filter.subDistrict },
         },
       })
     )

--- a/apps-api/backoffice/src/modules/address/repository.ts
+++ b/apps-api/backoffice/src/modules/address/repository.ts
@@ -13,12 +13,6 @@ export class AddressRepository {
           district: options?.district === undefined ? {} : { equals: options.district },
           subDistrict: options?.subDistrict === undefined ? {} : { equals: options.subDistrict },
         },
-        orderBy: [
-          { province: 'asc' },
-          { district: 'asc' },
-          { subDistrict: 'asc' },
-          { postalCode: 'asc' },
-        ],
       })
     )
   }

--- a/apps-api/backoffice/src/modules/address/repository.ts
+++ b/apps-api/backoffice/src/modules/address/repository.ts
@@ -5,13 +5,13 @@ import { fromPrismaPromise } from '../../utils/prisma'
 export class AddressRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async getAddresses(filter?: { province?: string; district?: string; subDistrict?: string }) {
+  async getAddresses(filters?: { province?: string; district?: string; subDistrict?: string }) {
     return fromPrismaPromise(
       this.prismaService.address.findMany({
         where: {
-          province: filter?.province === undefined ? {} : { equals: filter.province },
-          district: filter?.district === undefined ? {} : { equals: filter.district },
-          subDistrict: filter?.subDistrict === undefined ? {} : { equals: filter.subDistrict },
+          province: filters?.province === undefined ? {} : { equals: filters.province },
+          district: filters?.district === undefined ? {} : { equals: filters.district },
+          subDistrict: filters?.subDistrict === undefined ? {} : { equals: filters.subDistrict },
         },
       })
     )

--- a/apps-api/backoffice/src/modules/address/repository.ts
+++ b/apps-api/backoffice/src/modules/address/repository.ts
@@ -1,0 +1,26 @@
+import Elysia from 'elysia'
+import { PrismaService, PrismaServicePlugin } from '../../plugins/prisma'
+import { fromPrismaPromise } from '../../utils/prisma'
+
+export class AddressRepository {
+  constructor(private readonly prismaService: PrismaService) {}
+
+  async getAddresses() {
+    return fromPrismaPromise(
+      this.prismaService.address.findMany({
+        orderBy: [
+          { province: 'asc' },
+          { district: 'asc' },
+          { subDistrict: 'asc' },
+          { postalCode: 'asc' },
+        ],
+      })
+    )
+  }
+}
+
+export const AddressRepositoryPlugin = new Elysia({ name: 'AddressRepository' })
+  .use(PrismaServicePlugin)
+  .decorate(({ prismaService }) => ({
+    addressRepository: new AddressRepository(prismaService),
+  }))

--- a/apps-api/backoffice/src/modules/address/repository.ts
+++ b/apps-api/backoffice/src/modules/address/repository.ts
@@ -5,9 +5,12 @@ import { fromPrismaPromise } from '../../utils/prisma'
 export class AddressRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async getAddresses() {
+  async getAddresses(province?: string) {
     return fromPrismaPromise(
       this.prismaService.address.findMany({
+        where: {
+          province: province === undefined ? {} : { equals: province },
+        },
         orderBy: [
           { province: 'asc' },
           { district: 'asc' },

--- a/apps-api/backoffice/src/modules/address/repository.ts
+++ b/apps-api/backoffice/src/modules/address/repository.ts
@@ -5,11 +5,12 @@ import { fromPrismaPromise } from '../../utils/prisma'
 export class AddressRepository {
   constructor(private readonly prismaService: PrismaService) {}
 
-  async getAddresses(province?: string) {
+  async getAddresses(options?: { province?: string; district?: string }) {
     return fromPrismaPromise(
       this.prismaService.address.findMany({
         where: {
-          province: province === undefined ? {} : { equals: province },
+          province: options?.province === undefined ? {} : { equals: options.province },
+          district: options?.district === undefined ? {} : { equals: options.district },
         },
         orderBy: [
           { province: 'asc' },

--- a/apps-api/backoffice/src/modules/address/service.ts
+++ b/apps-api/backoffice/src/modules/address/service.ts
@@ -17,7 +17,7 @@ export class AddressService {
     const provinces: string[] = []
 
     addresses.value.forEach(({ province }) => {
-      if (!provinces.includes(province)) {
+      if (!provinceSet.has(province)) {
         provinces.push(province)
         provinceSet.add(province)
       }
@@ -27,7 +27,7 @@ export class AddressService {
   }
 
   async getDistricts(province?: string) {
-    const addresses = await this.addressRepository.getAddresses(province)
+    const addresses = await this.addressRepository.getAddresses({ province })
 
     if (addresses.isErr()) {
       return mapRawPrismaError(addresses.error)
@@ -37,13 +37,32 @@ export class AddressService {
     const districts: string[] = []
 
     addresses.value.forEach(({ district }) => {
-      if (!districts.includes(district)) {
+      if (!districtSet.has(district)) {
         districts.push(district)
         districtSet.add(district)
       }
     })
 
     return ok(districts)
+  }
+
+  async getSubDistricts(district?: string) {
+    const addresses = await this.addressRepository.getAddresses({ district })
+    if (addresses.isErr()) {
+      return mapRawPrismaError(addresses.error)
+    }
+
+    const subDistrictSet = new Set()
+    const subDistricts: string[] = []
+
+    addresses.value.forEach(({ subDistrict }) => {
+      if (!subDistrictSet.has(subDistrict)) {
+        subDistricts.push(subDistrict)
+        subDistrictSet.add(subDistrict)
+      }
+    })
+
+    return ok(subDistricts)
   }
 }
 

--- a/apps-api/backoffice/src/modules/address/service.ts
+++ b/apps-api/backoffice/src/modules/address/service.ts
@@ -1,0 +1,30 @@
+import { ok } from 'neverthrow'
+import { mapRawPrismaError } from '../../utils/prisma'
+import { AddressRepository, AddressRepositoryPlugin } from './repository'
+import Elysia from 'elysia'
+
+export class AddressService {
+  constructor(private readonly addressRepository: AddressRepository) {}
+
+  async getProvinces() {
+    const addresses = await this.addressRepository.getAddresses()
+
+    if (addresses.isErr()) {
+      return mapRawPrismaError(addresses.error)
+    }
+
+    const provinces = addresses.value.reduce((acc, { province }) => {
+      if (!acc.includes(province)) acc.push(province)
+
+      return acc
+    }, [] as string[])
+
+    return ok(provinces)
+  }
+}
+
+export const AddressServicePlugin = new Elysia({ name: 'AddressService' })
+  .use(AddressRepositoryPlugin)
+  .decorate(({ addressRepository }) => ({
+    addressService: new AddressService(addressRepository),
+  }))

--- a/apps-api/backoffice/src/modules/address/service.ts
+++ b/apps-api/backoffice/src/modules/address/service.ts
@@ -13,13 +13,37 @@ export class AddressService {
       return mapRawPrismaError(addresses.error)
     }
 
-    const provinces = addresses.value.reduce((acc, { province }) => {
-      if (!acc.includes(province)) acc.push(province)
+    const provinceSet = new Set()
+    const provinces: string[] = []
 
-      return acc
-    }, [] as string[])
+    addresses.value.forEach(({ province }) => {
+      if (!provinces.includes(province)) {
+        provinces.push(province)
+        provinceSet.add(province)
+      }
+    })
 
     return ok(provinces)
+  }
+
+  async getDistricts(province?: string) {
+    const addresses = await this.addressRepository.getAddresses(province)
+
+    if (addresses.isErr()) {
+      return mapRawPrismaError(addresses.error)
+    }
+
+    const districtSet = new Set()
+    const districts: string[] = []
+
+    addresses.value.forEach(({ district }) => {
+      if (!districts.includes(district)) {
+        districts.push(district)
+        districtSet.add(district)
+      }
+    })
+
+    return ok(districts)
   }
 }
 

--- a/apps-api/backoffice/src/modules/address/service.ts
+++ b/apps-api/backoffice/src/modules/address/service.ts
@@ -8,7 +8,6 @@ export class AddressService {
 
   async getProvinces() {
     const addresses = await this.addressRepository.getAddresses()
-
     if (addresses.isErr()) {
       return mapRawPrismaError(addresses.error)
     }
@@ -28,7 +27,6 @@ export class AddressService {
 
   async getDistricts(province?: string) {
     const addresses = await this.addressRepository.getAddresses({ province })
-
     if (addresses.isErr()) {
       return mapRawPrismaError(addresses.error)
     }
@@ -63,6 +61,26 @@ export class AddressService {
     })
 
     return ok(subDistricts)
+  }
+
+  async getPostalCodes(subDistrict?: string) {
+    const addresses = await this.addressRepository.getAddresses({ subDistrict })
+
+    if (addresses.isErr()) {
+      return mapRawPrismaError(addresses.error)
+    }
+
+    const postalCodeSet = new Set()
+    const postalCodes: string[] = []
+
+    addresses.value.forEach(({ postalCode }) => {
+      if (!postalCodeSet.has(postalCode)) {
+        postalCodes.push(postalCode)
+        postalCodeSet.add(postalCode)
+      }
+    })
+
+    return ok(postalCodes)
   }
 }
 

--- a/apps-api/backoffice/src/modules/address/service.ts
+++ b/apps-api/backoffice/src/modules/address/service.ts
@@ -22,6 +22,8 @@ export class AddressService {
       }
     })
 
+    provinces.sort()
+
     return ok(provinces)
   }
 
@@ -41,11 +43,14 @@ export class AddressService {
       }
     })
 
+    districts.sort()
+
     return ok(districts)
   }
 
   async getSubDistricts(district?: string) {
     const addresses = await this.addressRepository.getAddresses({ district })
+
     if (addresses.isErr()) {
       return mapRawPrismaError(addresses.error)
     }
@@ -60,12 +65,14 @@ export class AddressService {
       }
     })
 
+    subDistricts.sort()
+
     return ok(subDistricts)
   }
 
   async getPostalCodes(subDistrict?: string) {
     const addresses = await this.addressRepository.getAddresses({ subDistrict })
-
+    console.log('addresses', addresses)
     if (addresses.isErr()) {
       return mapRawPrismaError(addresses.error)
     }

--- a/apps-api/backoffice/src/modules/index.ts
+++ b/apps-api/backoffice/src/modules/index.ts
@@ -7,6 +7,7 @@ import { FacebookController } from './facebook'
 import { FeedController } from './feed'
 import { PollsController } from './polls'
 import { ProfileController } from './profile'
+import { AddressController } from './address'
 
 export const ApplicationController = new Elysia()
   .use(FeedController)
@@ -16,3 +17,4 @@ export const ApplicationController = new Elysia()
   .use(PollsController)
   .use(FacebookController)
   .use(BannerController)
+  .use(AddressController)


### PR DESCRIPTION
# Summary

- add `addresss` module
- add API
    - `GET /address/province` 
    - `GET /address/district?province=""` if `province` not specified, will return all `district`
    - `GET /address/subdistrict?district=""`  if `district` not specified, will return all `subdistrict`
    - `GET /address/postal-code?subdistrict=""` if `subdistrict` not specified, will return all `postal-code`

# Screenshots/Video

 ## `GET /address/province`

<img width="1070" height="745" alt="image" src="https://github.com/user-attachments/assets/3a4d19e4-2a5a-4182-b977-cbf23319916d" />

## `GET /address/district?province=""`

<img width="1222" height="510" alt="image" src="https://github.com/user-attachments/assets/4eacab55-b740-4d73-8494-78e47846306e" />

## `GET /address/subdistrict?district=""`

<img width="1302" height="397" alt="image" src="https://github.com/user-attachments/assets/993348bf-a89b-4f55-8c9b-2012fdbed658" />

## `GET /address/postal-code?subdistrict=""`

<img width="1295" height="392" alt="image" src="https://github.com/user-attachments/assets/bc8056de-f044-4961-8e65-c96f93369657" />

# Steps to Test
1.  run backend backoffice
2.  try in scalar in `http:localhost:2000/swagger`

# Checklist

- [x] Add Changeset
- [x] Add Linear ID in PR title
- [x] Perform Manual Testing

> [!NOTE]
