### PR TITLE
[PPLE-288] Optional auth guard still required user and remove announcement from query

### DIFF
--- a/.changeset/violet-papers-hear.md
+++ b/.changeset/violet-papers-hear.md
@@ -1,0 +1,5 @@
+---
+'@api/backoffice': patch
+---
+
+[[PPLE-288] [API] Feed Bug when no user authorize](https://linear.app/snts/issue/PPLE-288/api-feed-bug-when-no-user-authorize)

--- a/apps-api/backoffice/src/modules/auth/index.ts
+++ b/apps-api/backoffice/src/modules/auth/index.ts
@@ -27,7 +27,7 @@ export const AuthController = new Elysia({
       })
     },
     {
-      fetchOIDCUser: true,
+      requiredOIDCUser: true,
       query: RegisterUserQuery,
       response: {
         201: RegisterUserResponse,

--- a/apps-api/backoffice/src/modules/feed/repository.ts
+++ b/apps-api/backoffice/src/modules/feed/repository.ts
@@ -200,15 +200,6 @@ export class FeedRepository {
               },
             },
             {
-              announcement: {
-                topics: {
-                  some: {
-                    topicId,
-                  },
-                },
-              },
-            },
-            {
               poll: {
                 topics: {
                   some: {
@@ -261,21 +252,6 @@ export class FeedRepository {
                 hashTags: {
                   some: {
                     hashTagId,
-                  },
-                },
-              },
-            },
-            {
-              announcement: {
-                topics: {
-                  some: {
-                    topic: {
-                      hashTagInTopics: {
-                        some: {
-                          hashTagId,
-                        },
-                      },
-                    },
                   },
                 },
               },

--- a/apps-api/backoffice/src/plugins/auth-guard.ts
+++ b/apps-api/backoffice/src/plugins/auth-guard.ts
@@ -11,7 +11,7 @@ export class AuthGuard {
   constructor(private readonly authRepository: AuthRepository) {}
 
   async getOIDCUser(headers: Record<string, string | undefined>) {
-    const token = headers['authorization']?.replace('Bearer ', '').trim()
+    const token = headers['authorization']?.replace('Bearer', '').trim()
     if (!token)
       return err({ code: InternalErrorCode.UNAUTHORIZED, message: 'User not authenticated' })
 
@@ -48,13 +48,11 @@ export const AuthGuardPlugin = new Elysia({
     authGuard: new AuthGuard(authRepository),
   }))
   .macro({
-    fetchOIDCUser: {
+    requiredOIDCUser: {
       async resolve({ headers, status, authGuard }) {
         const oidcUserResult = await authGuard.getOIDCUser(headers)
 
         if (oidcUserResult.isErr()) {
-          if (oidcUserResult.error.code === InternalErrorCode.UNAUTHORIZED)
-            return { oidcUser: null }
           return mapErrorCodeToResponse(oidcUserResult.error, status)
         }
 


### PR DESCRIPTION
# Summary

- Fix optional auth guard still required logged in user
- Remove announcement condition from query

# Screenshots/Video

<img width="1171" height="541" alt="image" src="https://github.com/user-attachments/assets/8d46f030-54a9-418e-9a2a-04594dc58c64" />

# Steps to Test

1. Visit `http://localhost:2000` 
2. Attempt making request to `http://localhost:2000/auth/register` and `http://localhost:2000/feed/me`

# Checklist

- [x] Add Changeset
- [x] Add Linear ID in PR title
- [x] Perform Manual Testing

> [!NOTE]
