### PR TITLE
[PPLE-325] Facebook user access token could not use in backend

### DIFF
--- a/apps-api/backoffice/src/modules/facebook/models.ts
+++ b/apps-api/backoffice/src/modules/facebook/models.ts
@@ -1,5 +1,62 @@
 import { Static, t } from 'elysia'
 
+export const RequestAccessTokenQuery = t.Object({
+  code: t.String({
+    description: 'The authorization code received from Facebook after user consent',
+    minLength: 1,
+  }),
+  redirectUri: t.String({
+    description: 'The redirect URI used in the OAuth flow',
+    format: 'uri',
+  }),
+})
+export type RequestAccessTokenQuery = Static<typeof RequestAccessTokenQuery>
+
+export const RequestAccessTokenResponse = t.Object({
+  accessToken: t.String({
+    description: 'The access token for the user',
+  }),
+  tokenType: t.String({
+    description: 'The type of the access token',
+  }),
+  expiresIn: t.Optional(
+    t.Number({
+      description: 'The number of seconds until the access token expires',
+    })
+  ),
+})
+export type RequestAccessTokenResponse = Static<typeof RequestAccessTokenResponse>
+
+export const GetFacebookUserPageListQuery = t.Object({
+  facebookToken: t.String({
+    description: 'The access token for the Facebook user',
+    minLength: 1,
+  }),
+})
+export type GetFacebookUserPageListQuery = Static<typeof GetFacebookUserPageListQuery>
+
+export const GetFacebookUserPageListResponse = t.Array(
+  t.Object({
+    accessToken: t.String({
+      description: 'The access token for the linked Facebook page',
+    }),
+    id: t.String({
+      description: 'The ID of the Facebook page',
+    }),
+    name: t.String({
+      description: 'The name of the Facebook page',
+    }),
+    profilePictureUrl: t.String({
+      description: 'The URL of the profile picture for the Facebook page',
+      format: 'uri',
+    }),
+  }),
+  {
+    description: 'List of Facebook pages associated with the user',
+  }
+)
+export type GetFacebookUserPageListResponse = Static<typeof GetFacebookUserPageListResponse>
+
 export const GetLinkedFacebookPageResponse = t.Object({
   linkedFacebookPage: t.Nullable(
     t.Object({

--- a/apps-api/backoffice/src/modules/facebook/services.ts
+++ b/apps-api/backoffice/src/modules/facebook/services.ts
@@ -45,6 +45,27 @@ export class FacebookService {
   //   return await this.facebookRepository.subscribeToPostUpdates(userId, facebookPageId)
   // }
 
+  async getUserAccessToken(code: string, redirectUri: string) {
+    return await this.facebookRepository.getUserAccessToken(code, redirectUri)
+  }
+
+  async getUserPageList(facebookToken: string) {
+    const userPageListResult = await this.facebookRepository.getUserPageList(facebookToken)
+
+    if (userPageListResult.isErr()) {
+      return userPageListResult
+    }
+
+    return userPageListResult.map((result) =>
+      result.data.map((page) => ({
+        id: page.id,
+        name: page.name,
+        profilePictureUrl: page.picture.data.url,
+        accessToken: page.access_token,
+      }))
+    )
+  }
+
   async getLinkedFacebookPage(userId: string) {
     const linkedPageResult = await this.facebookRepository.getLinkedFacebookPage(userId)
 


### PR DESCRIPTION
# Summary

- Fix user access token that could not use in backend
- Remove unused endpoint from backend

# Screenshots/Video

<img width="1068" height="203" alt="image" src="https://github.com/user-attachments/assets/4f5075f3-a0a8-479b-bf8a-89d0f814642d" />

# Steps to Test

1. Please login with SSO first then go to playground page
2. Login with facebook and allows some pages
3. After click `Link with PPLE Today` button, it should successfully linked

# Checklist

- [x] Add Changeset
- [x] Add Linear ID in PR title
- [x] Perform Manual Testing

> [!NOTE]
