### PR TITLE
[PPLE-326] Get linked page available status endpoint

### DIFF
--- a/.changeset/bumpy-beds-stop.md
+++ b/.changeset/bumpy-beds-stop.md
@@ -1,0 +1,5 @@
+---
+'@api/backoffice': minor
+---
+
+[[PPLE-326] [API] Get linked page available status endpoint](https://linear.app/snts/issue/PPLE-326/api-get-linked-page-available-status-endpoint)

--- a/apps-api/backoffice/src/modules/facebook/index.ts
+++ b/apps-api/backoffice/src/modules/facebook/index.ts
@@ -4,6 +4,8 @@ import {
   GetFacebookUserPageListQuery,
   GetFacebookUserPageListResponse,
   GetLinkedFacebookPageResponse,
+  GetLinkedPageAvailableStatusQuery,
+  GetLinkedPageAvailableStatusResponse,
   LinkFacebookPageToUserBody,
   LinkFacebookPageToUserResponse,
   RequestAccessTokenQuery,
@@ -84,6 +86,26 @@ export const FacebookController = new Elysia({
   )
   .group('/linked-page', (app) =>
     app
+      .get(
+        '/available',
+        async ({ query, status, facebookService }) => {
+          const availableStatus = await facebookService.getLinkedPageAvailableStatus(query.pageIds)
+
+          if (availableStatus.isErr()) {
+            return mapErrorCodeToResponse(availableStatus.error, status)
+          }
+
+          return status(200, availableStatus.value)
+        },
+        {
+          requiredLocalUser: true,
+          query: GetLinkedPageAvailableStatusQuery,
+          response: {
+            200: GetLinkedPageAvailableStatusResponse,
+            ...createErrorSchema(InternalErrorCode.INTERNAL_SERVER_ERROR),
+          },
+        }
+      )
       .get(
         '/',
         async ({ status, facebookService, user }) => {

--- a/apps-api/backoffice/src/modules/facebook/models.ts
+++ b/apps-api/backoffice/src/modules/facebook/models.ts
@@ -35,6 +35,22 @@ export const GetFacebookUserPageListQuery = t.Object({
 })
 export type GetFacebookUserPageListQuery = Static<typeof GetFacebookUserPageListQuery>
 
+export const GetLinkedPageAvailableStatusQuery = t.Object({
+  pageIds: t.Array(
+    t.String({
+      description: 'The IDs of the Facebook pages to check availability for',
+      minLength: 1,
+    }),
+    { minItems: 1 }
+  ),
+})
+export type GetLinkedPageAvailableStatusQuery = Static<typeof GetLinkedPageAvailableStatusQuery>
+
+export const GetLinkedPageAvailableStatusResponse = t.Record(t.String(), t.Boolean())
+export type GetLinkedPageAvailableStatusResponse = Static<
+  typeof GetLinkedPageAvailableStatusResponse
+>
+
 export const GetFacebookUserPageListResponse = t.Array(
   t.Object({
     accessToken: t.String({

--- a/apps-api/backoffice/src/modules/facebook/repository.ts
+++ b/apps-api/backoffice/src/modules/facebook/repository.ts
@@ -511,6 +511,18 @@ export class FacebookRepository {
     return ok(response.value)
   }
 
+  async getLinkedPageAvailableStatus(pageIds: string[]) {
+    return await fromRepositoryPromise(
+      this.prismaService.facebookPage.findMany({
+        where: {
+          id: {
+            in: pageIds,
+          },
+        },
+      })
+    )
+  }
+
   async getLocalFacebookPage(pageId: string) {
     return await fromRepositoryPromise(
       this.prismaService.facebookPage.findUniqueOrThrow({

--- a/apps-api/backoffice/src/modules/facebook/services.ts
+++ b/apps-api/backoffice/src/modules/facebook/services.ts
@@ -1,5 +1,6 @@
 import Elysia from 'elysia'
 import { err, ok } from 'neverthrow'
+import * as R from 'remeda'
 
 import { FacebookRepository, FacebookRepositoryPlugin } from './repository'
 
@@ -63,6 +64,24 @@ export class FacebookService {
         profilePictureUrl: page.picture.data.url,
         accessToken: page.access_token,
       }))
+    )
+  }
+
+  async getLinkedPageAvailableStatus(pageIds: string[]) {
+    const existingPages = await this.facebookRepository.getLinkedPageAvailableStatus(pageIds)
+
+    if (existingPages.isErr()) {
+      return mapRepositoryError(existingPages.error)
+    }
+
+    return ok(
+      R.pipe(
+        existingPages.value,
+        R.map((page) => [page.id, page.managerId] as const),
+        R.fromEntries(),
+        (obj) => R.map(pageIds, (id) => [id, !obj[id]] as const),
+        R.fromEntries()
+      )
     )
   }
 


### PR DESCRIPTION
# Summary

- Implement get linked page available status endpoint

# Screenshots/Video

<img width="1308" height="512" alt="image" src="https://github.com/user-attachments/assets/17cfae57-538c-4609-b694-f98709d0993a" />

# Steps to Test

1. Visit `http://localhost:2000/swagger` and login with SSO
2. Then please make request to `http://localhost:2000/facebook/linked-page/available` with query `pageIds`

# Checklist

- [x] Add Changeset
- [x] Add Linear ID in PR title
- [x] Perform Manual Testing

> [!NOTE]
