### PR TITLE
[PPLE-385] Fix file service transaction and add test suite

### DIFF
--- a/.changeset/thin-baboons-build.md
+++ b/.changeset/thin-baboons-build.md
@@ -1,0 +1,6 @@
+---
+'@api/backoffice': patch
+'@pple-today/api-common': patch
+---
+
+[[PPLE-385] [API] Fix wrong logic when handle file transaction](https://linear.app/snts/issue/PPLE-385/api-fix-wrong-logic-when-handle-file-transaction)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
         run: pnpm turbo codegen
 
       - name: Run Type Check and Format Check
-        run: pnpm turbo typecheck format:check lint ${{ steps.get-turbo-filter.outputs.TURBO_FILTER }}
+        run: pnpm turbo test typecheck format:check lint ${{ steps.get-turbo-filter.outputs.TURBO_FILTER }}
 
       - name: Setup Prebuild Environment
         working-directory: apps-client/mobile

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
+    "test": "turbo run test",
     "format": "turbo run format",
     "format:check": "turbo run format:check",
     "typecheck": "turbo run typecheck",

--- a/packages/api-common/package.json
+++ b/packages/api-common/package.json
@@ -28,6 +28,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "format:check": "prettier --check .",
+    "test": "vitest --run",
     "lint": "eslint . --ext .ts,.tsx"
   },
   "keywords": [],
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.3.1",
-    "type-fest": "^4.41.0"
+    "type-fest": "^4.41.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/api-common/src/plugins/config.test.ts
+++ b/packages/api-common/src/plugins/config.test.ts
@@ -1,0 +1,69 @@
+import { t } from 'elysia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockedConfigDotenv = vi.fn()
+
+vi.mock('dotenv', () => ({
+  configDotenv: mockedConfigDotenv,
+}))
+
+describe('Config Plugin', async () => {
+  const { ConfigService } = await import('./config')
+
+  beforeEach(() => {
+    mockedConfigDotenv.mockClear()
+    process.env = {}
+  })
+
+  describe('ConfigService class', () => {
+    it('should initialize with correct parameters', () => {
+      process.env = {
+        TEST: 'test_value',
+      }
+
+      const configService = new ConfigService({
+        schema: t.Object({
+          TEST: t.String(),
+        }),
+        autoLoadEnv: false,
+      })
+
+      expect(configService).toBeDefined()
+      expect(configService.get('TEST')).toBe('test_value')
+    })
+
+    it('should load environment variables when autoLoadEnv is true', () => {
+      new ConfigService({
+        schema: t.Object({}),
+        autoLoadEnv: true,
+      })
+
+      expect(mockedConfigDotenv).toHaveBeenCalled()
+    })
+
+    it('should throw an error if environment variables do not match the schema', () => {
+      expect(() => {
+        process.env = {
+          TEST: 'not_a_number',
+        }
+        new ConfigService({
+          schema: t.Object({
+            TEST: t.Number(), // Expecting a number here
+          }),
+          autoLoadEnv: false,
+        })
+      }).toThrow()
+    })
+
+    it('should return default values for missing environment variables', () => {
+      const configService = new ConfigService({
+        schema: t.Object({
+          TEST: t.String({ default: 'default_value' }),
+        }),
+        autoLoadEnv: false,
+      })
+
+      expect(configService.get('TEST2' as any)).toBe(undefined)
+    })
+  })
+})

--- a/packages/api-common/src/services/file.test.ts
+++ b/packages/api-common/src/services/file.test.ts
@@ -16,7 +16,7 @@ class FileObject {
     return Promise.resolve()
   }
 
-  async move(destination: FileObject) {
+  async move(_: FileObject) {
     return Promise.resolve()
   }
 
@@ -28,7 +28,7 @@ class FileObject {
     return Promise.resolve()
   }
 
-  generateSignedPostPolicyV4(options: any): Promise<
+  generateSignedPostPolicyV4(_: any): Promise<
     [
       {
         url: string
@@ -51,7 +51,7 @@ class FileObject {
     ])
   }
 
-  getSignedUrl(options: any): Promise<string> {
+  getSignedUrl(_: any): Promise<string> {
     return Promise.resolve(
       `https://storage.googleapis.com/fake-bucket/${encodeURIComponent(this.path)}`
     )
@@ -71,7 +71,7 @@ class Bucket {
 }
 
 class Storage {
-  constructor(config: any) {}
+  constructor(_: any) {}
 
   bucket(name: string) {
     return new Bucket(name)

--- a/packages/api-common/src/services/file.test.ts
+++ b/packages/api-common/src/services/file.test.ts
@@ -858,6 +858,12 @@ describe('File service', async () => {
           message: 'An unknown error occurred',
           originalError: new Error('Some error'),
         })
+        expect(loggerService.warn).toBeCalledWith({
+          message: 'File transaction failed, rolling back changes',
+          context: {
+            err: new Error('Some error'),
+          },
+        })
 
         // 6 + 6 for move to public and private folder
         // 6 for move rollback from private folder
@@ -920,6 +926,16 @@ describe('File service', async () => {
         expect(txResult._unsafeUnwrapErr()).toEqual({
           code: 'SOME_ERROR_CODE',
           message: 'Some error',
+        })
+
+        expect(loggerService.warn).toBeCalledWith({
+          message: 'File transaction failed, rolling back changes',
+          context: {
+            err: {
+              code: 'SOME_ERROR_CODE',
+              message: 'Some error',
+            },
+          },
         })
 
         // 6 + 6 for move to public and private folder
@@ -1007,6 +1023,16 @@ describe('File service', async () => {
               return tx.bulkMoveToPublicFolder(['temp/folder/file1.txt'])
             })
           )
+
+          expect(loggerService.warn).toBeCalledWith({
+            message: 'File transaction failed, rolling back changes',
+            context: {
+              err: {
+                code: InternalErrorCode.FILE_CHANGE_PERMISSION_ERROR,
+                message: 'Failed to make file public',
+              },
+            },
+          })
 
           expect(txResult.isErr()).toBe(true)
           expect(txResult._unsafeUnwrapErr()).toEqual({

--- a/packages/api-common/src/services/file.test.ts
+++ b/packages/api-common/src/services/file.test.ts
@@ -1,0 +1,1027 @@
+import { PolicyFields } from '@google-cloud/storage'
+import { ok } from 'neverthrow'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { InternalErrorCode } from '../dtos'
+import { err, fromRepositoryPromise } from '../utils'
+
+class FileObject {
+  constructor(private path: string) {}
+
+  async makePublic() {
+    return Promise.resolve()
+  }
+
+  async makePrivate() {
+    return Promise.resolve()
+  }
+
+  async move(destination: FileObject) {
+    return Promise.resolve()
+  }
+
+  publicUrl() {
+    return `https://storage.googleapis.com/fake-bucket/${encodeURIComponent(this.path)}`
+  }
+
+  delete() {
+    return Promise.resolve()
+  }
+
+  generateSignedPostPolicyV4(options: any): Promise<
+    [
+      {
+        url: string
+        fields: PolicyFields
+      },
+    ]
+  > {
+    return Promise.resolve([
+      {
+        url: `https://storage.googleapis.com/fake-bucket/${encodeURIComponent(this.path)}`,
+        fields: {
+          key: this.path,
+          acl: 'public-read',
+          'Content-Type': 'application/octet-stream',
+          'x-goog-credential': 'test-credential',
+          'x-goog-date': 'test-date',
+          'x-goog-algorithm': 'test-algorithm',
+        },
+      },
+    ])
+  }
+
+  getSignedUrl(options: any): Promise<string> {
+    return Promise.resolve(
+      `https://storage.googleapis.com/fake-bucket/${encodeURIComponent(this.path)}`
+    )
+  }
+}
+
+class Bucket {
+  private name: string
+
+  constructor(name: string) {
+    this.name = name
+  }
+
+  file(path: string) {
+    return new FileObject(path)
+  }
+}
+
+class Storage {
+  constructor(config: any) {}
+
+  bucket(name: string) {
+    return new Bucket(name)
+  }
+}
+
+const StorageConstructor = vi.fn().mockImplementation((config) => {
+  return new Storage(config)
+})
+
+vi.mock('@google-cloud/storage', () => {
+  return {
+    Storage: StorageConstructor,
+  }
+})
+
+const loggerService = {
+  log: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}
+
+const StorageBucketSpy = vi.spyOn(Storage.prototype, 'bucket')
+const BucketFileSpy = vi.spyOn(Bucket.prototype, 'file')
+const FileMakePublicSpy = vi.spyOn(FileObject.prototype, 'makePublic')
+const FileMakePrivateSpy = vi.spyOn(FileObject.prototype, 'makePrivate')
+const FileMoveSpy = vi.spyOn(FileObject.prototype, 'move')
+const FilePublicUrlSpy = vi.spyOn(FileObject.prototype, 'publicUrl')
+const FileDeleteSpy = vi.spyOn(FileObject.prototype, 'delete')
+const FileGenerateSignedPostPolicyV4Spy = vi.spyOn(
+  FileObject.prototype,
+  'generateSignedPostPolicyV4'
+)
+const FileGetSignedUrlSpy = vi.spyOn(FileObject.prototype, 'getSignedUrl')
+const DateNowSpy = vi.spyOn(Date, 'now')
+
+describe('File service', async () => {
+  const { FileService, FileTransactionService } = await import('./file')
+
+  beforeEach(() => {
+    StorageConstructor.mockClear()
+    StorageBucketSpy.mockClear()
+    BucketFileSpy.mockClear()
+    FileMakePublicSpy.mockReset()
+    FileMakePrivateSpy.mockReset()
+    FileMoveSpy.mockReset()
+    FilePublicUrlSpy.mockReset()
+    FileDeleteSpy.mockReset()
+    FileGetSignedUrlSpy.mockReset()
+    FileGenerateSignedPostPolicyV4Spy.mockReset()
+    DateNowSpy.mockReset()
+
+    loggerService.log.mockReset()
+    loggerService.error.mockReset()
+    loggerService.info.mockReset()
+    loggerService.warn.mockReset()
+  })
+
+  const createFileService = () => {
+    const storage = new FileService(
+      {
+        projectId: 'test-project-id',
+        bucketName: 'test-bucket-name',
+        clientEmail: 'test-client-email',
+        privateKey: 'test-private-key',
+      },
+      loggerService as any
+    )
+    return storage
+  }
+
+  describe('FileService class', () => {
+    it('should initialize with correct parameters', () => {
+      createFileService()
+      expect(StorageConstructor).toHaveBeenCalledWith({
+        projectId: 'test-project-id',
+        credentials: {
+          client_email: 'test-client-email',
+          private_key: 'test-private-key',
+        },
+      })
+      expect(StorageBucketSpy).toHaveBeenCalledWith('test-bucket-name')
+    })
+
+    describe('createUploadSignedUrl', () => {
+      it('should call generateSignedPostPolicyV4 on the file object when createUploadSignedUrl is called', async () => {
+        DateNowSpy.mockReturnValue(1609459200000) // Mock current date to Jan 1, 2021
+        const fileService = createFileService()
+        await fileService.createUploadSignedUrl('path/to/file.txt', {
+          expiresIn: 60,
+          maxSize: 5 * 1024 * 1024,
+          contentType: 'application/octet-stream',
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file.txt')
+        expect(FileGenerateSignedPostPolicyV4Spy).toHaveBeenCalledWith({
+          expires: 1609459200000 + 60000,
+          fields: {
+            'Content-Type': 'application/octet-stream',
+          },
+          conditions: [
+            ['content-length-range', 0, 5 * 1024 * 1024],
+            ['eq', '$Content-Type', 'application/octet-stream'],
+          ],
+        })
+      })
+
+      it('should return correct error if generateSignedPostPolicyV4 fails', async () => {
+        FileGenerateSignedPostPolicyV4Spy.mockImplementationOnce(async () => {
+          throw new Error('Failed to generate signed URL')
+        })
+
+        const fileService = createFileService()
+        const result = await fileService.createUploadSignedUrl('path/to/file.txt', {
+          expiresIn: 60,
+          maxSize: 5 * 1024 * 1024,
+          contentType: 'application/octet-stream',
+        })
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toEqual({
+          code: InternalErrorCode.FILE_CREATE_SIGNED_URL_ERROR,
+          message: 'Failed to generate signed URL',
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file.txt')
+        expect(FileGenerateSignedPostPolicyV4Spy).toHaveBeenCalled()
+      })
+    })
+
+    describe('markAsPublic', () => {
+      it('should call makeAsPublic on the file object when markAsPublic is called', async () => {
+        const fileService = createFileService()
+        await fileService.markAsPublic('path/to/file.txt')
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file.txt')
+        expect(FileMakePublicSpy).toHaveBeenCalled()
+      })
+
+      it('should return correct error if makeAsPublic fails', async () => {
+        FileMakePublicSpy.mockImplementationOnce(async () => {
+          throw new Error('Failed to make file public')
+        })
+
+        const fileService = createFileService()
+        const result = await fileService.markAsPublic('path/to/file.txt')
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toEqual({
+          code: InternalErrorCode.FILE_CHANGE_PERMISSION_ERROR,
+          message: 'Failed to make file public',
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file.txt')
+        expect(FileMakePublicSpy).toHaveBeenCalled()
+      })
+    })
+
+    describe('markAsPrivate', () => {
+      it('should call makeAsPrivate on the file object when markAsPrivate is called', async () => {
+        const fileService = createFileService()
+        await fileService.markAsPrivate('path/to/file.txt')
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file.txt')
+        expect(FileMakePrivateSpy).toHaveBeenCalled()
+      })
+
+      it('should return correct error if makeAsPrivate fails', async () => {
+        FileMakePrivateSpy.mockImplementationOnce(async () => {
+          throw new Error('Failed to make file private')
+        })
+
+        const fileService = createFileService()
+        const result = await fileService.markAsPrivate('path/to/file.txt')
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toEqual({
+          code: InternalErrorCode.FILE_CHANGE_PERMISSION_ERROR,
+          message: 'Failed to make file private',
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file.txt')
+        expect(FileMakePrivateSpy).toHaveBeenCalled()
+      })
+    })
+
+    describe('bulkMoveToPublicFolder', () => {
+      it('should call markAsPublic with new path when bulkMoveToPublicFolder is called', async () => {
+        const fileService = createFileService()
+        await fileService.bulkMoveToPublicFolder(['temp/folder/file1.txt', 'temp/folder/file2.txt'])
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('public/folder/file1.txt')
+        expect(BucketFileSpy).toHaveBeenCalledWith('public/folder/file2.txt')
+
+        expect(FileMakePublicSpy).toHaveBeenCalledTimes(2)
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(2)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('public/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('public/folder/file2.txt'))
+      })
+
+      it('should return correct error if moveFile fails', async () => {
+        FileMoveSpy.mockImplementation(async () => {
+          throw new Error('Failed to move file')
+        })
+
+        const fileService = createFileService()
+        const result = await fileService.bulkMoveToPublicFolder([
+          'temp/folder/file1.txt',
+          'temp/folder/file2.txt',
+        ])
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toEqual({
+          code: InternalErrorCode.FILE_MOVE_ERROR,
+          message: 'Failed to move one or more files',
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('public/folder/file1.txt')
+        expect(BucketFileSpy).toHaveBeenCalledWith('public/folder/file2.txt')
+
+        expect(FileMakePublicSpy).toHaveBeenCalledTimes(0)
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(2)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('public/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('public/folder/file2.txt'))
+      })
+
+      it('should return correct error if markAsPublic fails', async () => {
+        FileMakePublicSpy.mockImplementation(async () => {
+          throw new Error('Failed to make file public')
+        })
+
+        const fileService = createFileService()
+        const result = await fileService.bulkMoveToPublicFolder([
+          'temp/folder/file1.txt',
+          'temp/folder/file2.txt',
+        ])
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toEqual({
+          code: InternalErrorCode.FILE_MOVE_ERROR,
+          message: 'Failed to move one or more files',
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('public/folder/file1.txt')
+        expect(BucketFileSpy).toHaveBeenCalledWith('public/folder/file2.txt')
+
+        expect(FileMakePublicSpy).toHaveBeenCalledTimes(2)
+
+        // 2 for move to public folder, 2 for move rollback
+        expect(FileMoveSpy).toHaveBeenCalledTimes(4)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('public/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('public/folder/file2.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(3, new FileObject('temp/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(4, new FileObject('temp/folder/file2.txt'))
+      })
+    })
+
+    describe('bulkMoveToPrivateFolder', () => {
+      it('should call markAsPrivate with new path when bulkMoveToPrivateFolder is called', async () => {
+        const fileService = createFileService()
+        await fileService.bulkMoveToPrivateFolder([
+          'temp/folder/file1.txt',
+          'temp/folder/file2.txt',
+        ])
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('private/folder/file1.txt')
+        expect(BucketFileSpy).toHaveBeenCalledWith('private/folder/file2.txt')
+
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(2)
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(2)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('private/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('private/folder/file2.txt'))
+      })
+
+      it('should return correct error if moveFile fails', async () => {
+        FileMoveSpy.mockImplementation(async () => {
+          throw new Error('Failed to move file')
+        })
+
+        const fileService = createFileService()
+        const result = await fileService.bulkMoveToPrivateFolder([
+          'temp/folder/file1.txt',
+          'temp/folder/file2.txt',
+        ])
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toEqual({
+          code: InternalErrorCode.FILE_MOVE_ERROR,
+          message: 'Failed to move one or more files',
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('private/folder/file1.txt')
+        expect(BucketFileSpy).toHaveBeenCalledWith('private/folder/file2.txt')
+
+        expect(FileMakePublicSpy).toHaveBeenCalledTimes(0)
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(2)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('private/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('private/folder/file2.txt'))
+      })
+
+      it('should return correct error if markAsPrivate fails', async () => {
+        FileMakePrivateSpy.mockImplementation(async () => {
+          throw new Error('Failed to make file private')
+        })
+
+        const fileService = createFileService()
+        const result = await fileService.bulkMoveToPrivateFolder([
+          'temp/folder/file1.txt',
+          'temp/folder/file2.txt',
+        ])
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toEqual({
+          code: InternalErrorCode.FILE_MOVE_ERROR,
+          message: 'Failed to move one or more files',
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('private/folder/file1.txt')
+        expect(BucketFileSpy).toHaveBeenCalledWith('private/folder/file2.txt')
+
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(2)
+
+        // 2 for move to private folder, 2 for move rollback
+        expect(FileMoveSpy).toHaveBeenCalledTimes(4)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('private/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('private/folder/file2.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(3, new FileObject('temp/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(4, new FileObject('temp/folder/file2.txt'))
+      })
+    })
+
+    describe('bulkDeleteFile', () => {
+      it('should call move file with correct paths when bulkDeleteFile is called', async () => {
+        const fileService = createFileService()
+        await fileService.bulkDeleteFile(['path/to/file1.txt', 'path/to/file2.txt'])
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file1.txt')
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file2.txt')
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(2)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('deleted/to/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('deleted/to/file2.txt'))
+
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(2)
+      })
+
+      it('should return correct error if moveFile fails', async () => {
+        FileMoveSpy.mockImplementation(async () => {
+          throw new Error('Failed to move file')
+        })
+
+        const fileService = createFileService()
+        const result = await fileService.bulkDeleteFile(['path/to/file1.txt', 'path/to/file2.txt'])
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toEqual({
+          code: InternalErrorCode.FILE_MOVE_ERROR,
+          message: 'Failed to move one or more files',
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file1.txt')
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file2.txt')
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(2)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('deleted/to/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('deleted/to/file2.txt'))
+
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(0)
+      })
+
+      it('should return correct error if markAsPrivate fails', async () => {
+        FileMakePrivateSpy.mockImplementation(async () => {
+          throw new Error('Failed to make file private')
+        })
+
+        const fileService = createFileService()
+        const result = await fileService.bulkDeleteFile(['path/to/file1.txt', 'path/to/file2.txt'])
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toEqual({
+          code: InternalErrorCode.FILE_MOVE_ERROR,
+          message: 'Failed to move one or more files',
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('deleted/to/file1.txt')
+        expect(BucketFileSpy).toHaveBeenCalledWith('deleted/to/file2.txt')
+
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(2)
+
+        // 2 for move to deleted folder, 2 for move rollback
+        expect(FileMoveSpy).toHaveBeenCalledTimes(4)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('deleted/to/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('deleted/to/file2.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(3, new FileObject('path/to/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(4, new FileObject('path/to/file2.txt'))
+      })
+    })
+
+    describe('getPublicFileUrl', () => {
+      it('should return the public URL of the file when getPublicUrl is called', async () => {
+        const fileService = createFileService()
+        const publicUrl = fileService.getPublicFileUrl('path/to/file.txt')
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file.txt')
+        expect(FilePublicUrlSpy).toHaveBeenCalled()
+        expect(publicUrl).toEqual('https://storage.googleapis.com/fake-bucket/path%2Fto%2Ffile.txt')
+      })
+    })
+
+    describe('bulkGetPublicFileUrl', () => {
+      it('should return the public URLs of the files when bulkGetPublicFileUrl is called', async () => {
+        const fileService = createFileService()
+        const publicUrls = fileService.bulkGetPublicFileUrl([
+          'path/to/file1.txt',
+          'path/to/file2.txt',
+        ])
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file1.txt')
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file2.txt')
+        expect(FilePublicUrlSpy).toHaveBeenCalledTimes(2)
+        expect(publicUrls).toEqual([
+          'https://storage.googleapis.com/fake-bucket/path%2Fto%2Ffile1.txt',
+          'https://storage.googleapis.com/fake-bucket/path%2Fto%2Ffile2.txt',
+        ])
+      })
+    })
+
+    describe('getFilePathFromMimeType', () => {
+      it('should get correct file path when getFilePath is called', async () => {
+        const fileService = createFileService()
+        const filePath = fileService.getFilePathFromMimeType(
+          'public/folder/file',
+          'application/vnd.ms-powerpoint'
+        )
+
+        expect(filePath).toEqual(ok('public/folder/file.ppt'))
+      })
+    })
+
+    describe('removeFile', () => {
+      it('should call delete on the file object when removeFile is called', async () => {
+        const fileService = createFileService()
+        await fileService.removeFile('path/to/file.txt')
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file.txt')
+        expect(FileDeleteSpy).toHaveBeenCalled()
+      })
+    })
+
+    describe('getFileSignedUrl', () => {
+      it('should call getSignedUrl on the file object when getFileSignedUrl is called', async () => {
+        DateNowSpy.mockReturnValue(1609459200000) // Mock current date to Jan 1, 2021
+        const fileService = createFileService()
+        await fileService.getFileSignedUrl('path/to/file.txt', {
+          expiresIn: 15 * 60, // 1 hour
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file.txt')
+        expect(FileGetSignedUrlSpy).toHaveBeenCalledWith({
+          version: 'v4',
+          action: 'read',
+          expires: 1609459200000 + 15 * 60 * 1000,
+        })
+      })
+
+      it('should return correct error if getSignedUrl fails', async () => {
+        FileGetSignedUrlSpy.mockImplementationOnce(async () => {
+          throw new Error('Failed to get signed URL')
+        })
+
+        const fileService = createFileService()
+        const result = await fileService.getFileSignedUrl('path/to/file.txt')
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toEqual({
+          code: InternalErrorCode.FILE_CREATE_SIGNED_URL_ERROR,
+          message: 'Failed to get signed URL',
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file.txt')
+        expect(FileGetSignedUrlSpy).toHaveBeenCalled()
+      })
+    })
+
+    describe('bulkGetFileSignedUrl', () => {
+      it('should call getSignedUrl on the file objects when bulkGetFileSignedUrl is called', async () => {
+        DateNowSpy.mockReturnValue(1609459200000) // Mock current date to Jan 1, 2021
+        const fileService = createFileService()
+        await fileService.bulkGetFileSignedUrl(['path/to/file1.txt', 'path/to/file2.txt'], {
+          expiresIn: 30 * 60, // 30 minutes
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file1.txt')
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file2.txt')
+        expect(FileGetSignedUrlSpy).toHaveBeenCalledTimes(2)
+        expect(FileGetSignedUrlSpy).toHaveBeenNthCalledWith(1, {
+          version: 'v4',
+          action: 'read',
+          expires: 1609459200000 + 30 * 60 * 1000,
+        })
+        expect(FileGetSignedUrlSpy).toHaveBeenNthCalledWith(2, {
+          version: 'v4',
+          action: 'read',
+          expires: 1609459200000 + 30 * 60 * 1000,
+        })
+      })
+
+      it('should return correct error if getSignedUrl fails', async () => {
+        FileGetSignedUrlSpy.mockImplementationOnce(async () => {
+          throw new Error('Failed to get signed URL')
+        })
+
+        const fileService = createFileService()
+        const result = await fileService.bulkGetFileSignedUrl([
+          'path/to/file1.txt',
+          'path/to/file2.txt',
+        ])
+
+        expect(result.isErr()).toBe(true)
+        expect(result._unsafeUnwrapErr()).toEqual({
+          code: InternalErrorCode.FILE_CREATE_SIGNED_URL_ERROR,
+          message: 'Failed to get one or more signed URLs',
+        })
+
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file1.txt')
+        expect(BucketFileSpy).toHaveBeenCalledWith('path/to/file2.txt')
+        expect(FileGetSignedUrlSpy).toHaveBeenCalledTimes(2)
+      })
+    })
+  })
+
+  describe('FileTransactionService class', () => {
+    it('should return an instance of FileTransactionService when getTransactionService is called', async () => {
+      const fileService = createFileService()
+      const txResult = await fromRepositoryPromise(
+        fileService.$transaction(async () => {
+          return {}
+        })
+      )
+
+      const [result, txService] = txResult._unsafeUnwrap()
+
+      expect(txService).toBeInstanceOf(FileTransactionService)
+      expect(result).toEqual({})
+    })
+
+    describe('bulkMoveToPublicFolder', () => {
+      it('should call moveFile with changed permission when called within a transaction', async () => {
+        const fileService = createFileService()
+        const txResult = await fromRepositoryPromise(
+          fileService.$transaction(async (tx) => {
+            return tx.bulkMoveToPublicFolder([
+              'temp/folder/file1.txt',
+              'temp/folder/file2.txt',
+              'temp/folder/file3.txt',
+            ])
+          })
+        )
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(3)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('public/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('public/folder/file2.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(3, new FileObject('public/folder/file3.txt'))
+
+        expect(FileMakePublicSpy).toHaveBeenCalledTimes(3)
+
+        expect(txResult.isOk()).toBe(true)
+
+        expect(txResult._unsafeUnwrap()).toEqual([
+          ok(['public/folder/file1.txt', 'public/folder/file2.txt', 'public/folder/file3.txt']),
+          expect.any(FileTransactionService),
+        ])
+      })
+
+      it('should not call move if files are not changed when called within a transaction', async () => {
+        const fileService = createFileService()
+        const txResult = await fromRepositoryPromise(
+          fileService.$transaction(async (tx) => {
+            return tx.bulkMoveToPublicFolder([
+              'public/folder/file1.txt',
+              'public/folder/file2.txt',
+              'public/folder/file3.txt',
+            ])
+          })
+        )
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(0)
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(0)
+
+        expect(txResult.isOk()).toBe(true)
+
+        expect(txResult._unsafeUnwrap()).toEqual([
+          ok(['public/folder/file1.txt', 'public/folder/file2.txt', 'public/folder/file3.txt']),
+          expect.any(FileTransactionService),
+        ])
+      })
+    })
+
+    describe('bulkMoveToPrivateFolder', () => {
+      it('should call move with changed permission when called within a transaction', async () => {
+        const fileService = createFileService()
+        const txResult = await fromRepositoryPromise(
+          fileService.$transaction(async (tx) => {
+            return tx.bulkMoveToPrivateFolder([
+              'public/folder/file1.txt',
+              'public/folder/file2.txt',
+              'public/folder/file3.txt',
+            ])
+          })
+        )
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(3)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('private/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('private/folder/file2.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(3, new FileObject('private/folder/file3.txt'))
+
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(3)
+
+        expect(txResult.isOk()).toBe(true)
+
+        expect(txResult._unsafeUnwrap()).toEqual([
+          ok(['private/folder/file1.txt', 'private/folder/file2.txt', 'private/folder/file3.txt']),
+          expect.any(FileTransactionService),
+        ])
+      })
+
+      it('should call move with unchanged permission when called within a transaction', async () => {
+        const fileService = createFileService()
+        const txResult = await fromRepositoryPromise(
+          fileService.$transaction(async (tx) => {
+            return tx.bulkMoveToPrivateFolder([
+              'temp/folder/file1.txt',
+              'temp/folder/file2.txt',
+              'temp/folder/file3.txt',
+            ])
+          })
+        )
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(3)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('private/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('private/folder/file2.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(3, new FileObject('private/folder/file3.txt'))
+
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(0)
+
+        expect(txResult.isOk()).toBe(true)
+
+        expect(txResult._unsafeUnwrap()).toEqual([
+          ok(['private/folder/file1.txt', 'private/folder/file2.txt', 'private/folder/file3.txt']),
+          expect.any(FileTransactionService),
+        ])
+      })
+
+      it('should not call move if files are not changed when called within a transaction', async () => {
+        const fileService = createFileService()
+        const txResult = await fromRepositoryPromise(
+          fileService.$transaction(async (tx) => {
+            return tx.bulkMoveToPrivateFolder([
+              'private/folder/file1.txt',
+              'private/folder/file2.txt',
+              'private/folder/file3.txt',
+            ])
+          })
+        )
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(0)
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(0)
+
+        expect(txResult.isOk()).toBe(true)
+
+        expect(txResult._unsafeUnwrap()).toEqual([
+          ok(['private/folder/file1.txt', 'private/folder/file2.txt', 'private/folder/file3.txt']),
+          expect.any(FileTransactionService),
+        ])
+      })
+    })
+
+    describe('bulkDeleteFile', () => {
+      it('should call move with changed permission when called within a transaction', async () => {
+        const fileService = createFileService()
+        const txResult = await fromRepositoryPromise(
+          fileService.$transaction(async (tx) => {
+            return tx.bulkDeleteFile([
+              'public/folder/file1.txt',
+              'public/folder/file2.txt',
+              'public/folder/file3.txt',
+            ])
+          })
+        )
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(3)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('deleted/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('deleted/folder/file2.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(3, new FileObject('deleted/folder/file3.txt'))
+
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(3)
+
+        expect(txResult.isOk()).toBe(true)
+
+        expect(txResult._unsafeUnwrap()).toEqual([
+          ok(['deleted/folder/file1.txt', 'deleted/folder/file2.txt', 'deleted/folder/file3.txt']),
+          expect.any(FileTransactionService),
+        ])
+      })
+
+      it('should call move with unchanged permission when called within a transaction', async () => {
+        const fileService = createFileService()
+        const txResult = await fromRepositoryPromise(
+          fileService.$transaction(async (tx) => {
+            return tx.bulkDeleteFile([
+              'temp/folder/file1.txt',
+              'temp/folder/file2.txt',
+              'temp/folder/file3.txt',
+            ])
+          })
+        )
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(3)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('deleted/folder/file1.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('deleted/folder/file2.txt'))
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(3, new FileObject('deleted/folder/file3.txt'))
+
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(0)
+
+        expect(txResult.isOk()).toBe(true)
+
+        expect(txResult._unsafeUnwrap()).toEqual([
+          ok(['deleted/folder/file1.txt', 'deleted/folder/file2.txt', 'deleted/folder/file3.txt']),
+          expect.any(FileTransactionService),
+        ])
+      })
+
+      it('should not call move if files are not changed when called within a transaction', async () => {
+        const fileService = createFileService()
+        const txResult = await fromRepositoryPromise(
+          fileService.$transaction(async (tx) => {
+            return tx.bulkDeleteFile([
+              'deleted/to/file1.txt',
+              'deleted/to/file2.txt',
+              'deleted/to/file3.txt',
+            ] as any)
+          })
+        )
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(0)
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(0)
+
+        expect(txResult.isOk()).toBe(true)
+
+        expect(txResult._unsafeUnwrap()).toEqual([
+          ok(['deleted/to/file1.txt', 'deleted/to/file2.txt', 'deleted/to/file3.txt']),
+          expect.any(FileTransactionService),
+        ])
+      })
+    })
+
+    describe('rollback', () => {
+      it('should be called with correct operation order when throw error', async () => {
+        const fileService = createFileService()
+        const txResult = await fromRepositoryPromise(
+          fileService.$transaction(async (tx) => {
+            await tx.bulkMoveToPublicFolder([
+              'temp/folder/file1.txt',
+              'temp/folder/file2.txt',
+              'temp/folder/file3.txt',
+            ])
+            await tx.bulkMoveToPrivateFolder([
+              'public/folder/file4.txt',
+              'public/folder/file5.txt',
+              'public/folder/file6.txt',
+            ])
+            throw new Error('Some error')
+          })
+        )
+
+        expect(txResult.isErr()).toBe(true)
+        expect(txResult._unsafeUnwrapErr()).toEqual({
+          code: 'UNKNOWN_ERROR',
+          message: 'An unknown error occurred',
+          originalError: new Error('Some error'),
+        })
+
+        // 6 + 6 for move to public and private folder
+        // 6 for move rollback from private folder
+        // 6 for move rollback from public folder
+        expect(FileMoveSpy).toHaveBeenCalledTimes(12)
+        expect(FileMakePublicSpy).toHaveBeenCalledTimes(6)
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(6)
+
+        // Normal Operations
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('public/folder/file1.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(1)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('public/folder/file2.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(2)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(3, new FileObject('public/folder/file3.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(3)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(4, new FileObject('private/folder/file4.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(1)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(5, new FileObject('private/folder/file5.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(2)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(6, new FileObject('private/folder/file6.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(3)
+
+        // Rollback Operations
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(7, new FileObject('public/folder/file6.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(4)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(8, new FileObject('public/folder/file5.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(5)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(9, new FileObject('public/folder/file4.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(6)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(10, new FileObject('temp/folder/file3.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(4)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(11, new FileObject('temp/folder/file2.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(5)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(12, new FileObject('temp/folder/file1.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(6)
+      })
+
+      it('should be called with correct operation order when return neverthrow error', async () => {
+        const fileService = createFileService()
+        const txResult = await fromRepositoryPromise(
+          fileService.$transaction(async (tx) => {
+            await tx.bulkMoveToPublicFolder([
+              'temp/folder/file1.txt',
+              'temp/folder/file2.txt',
+              'temp/folder/file3.txt',
+            ])
+            await tx.bulkMoveToPrivateFolder([
+              'public/folder/file4.txt',
+              'public/folder/file5.txt',
+              'public/folder/file6.txt',
+            ])
+            return err({
+              code: 'SOME_ERROR_CODE',
+              message: 'Some error',
+            } as any)
+          })
+        )
+
+        expect(txResult.isErr()).toBe(true)
+        expect(txResult._unsafeUnwrapErr()).toEqual({
+          code: 'SOME_ERROR_CODE',
+          message: 'Some error',
+        })
+
+        // 6 + 6 for move to public and private folder
+        // 6 for move rollback from private folder
+        // 6 for move rollback from public folder
+        expect(FileMoveSpy).toHaveBeenCalledTimes(12)
+        expect(FileMakePublicSpy).toHaveBeenCalledTimes(6)
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(6)
+
+        // Normal Operations
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('public/folder/file1.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(1)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('public/folder/file2.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(2)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(3, new FileObject('public/folder/file3.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(3)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(4, new FileObject('private/folder/file4.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(1)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(5, new FileObject('private/folder/file5.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(2)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(6, new FileObject('private/folder/file6.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(3)
+
+        // Rollback Operations
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(7, new FileObject('public/folder/file6.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(4)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(8, new FileObject('public/folder/file5.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(5)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(9, new FileObject('public/folder/file4.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(6)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(10, new FileObject('temp/folder/file3.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(4)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(11, new FileObject('temp/folder/file2.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(5)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(12, new FileObject('temp/folder/file1.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(6)
+      })
+
+      it('should be called with correct operation order when manually rollback', async () => {
+        const fileService = createFileService()
+        const txResult = await fromRepositoryPromise(
+          fileService.$transaction(async (tx) => {
+            await tx.bulkMoveToPublicFolder(['temp/folder/file1.txt'])
+            await tx.bulkMoveToPrivateFolder(['public/folder/file4.txt'])
+            return {}
+          })
+        )
+
+        expect(txResult.isOk()).toBe(true)
+        expect(txResult._unsafeUnwrap()[0]).toEqual({})
+
+        await txResult._unsafeUnwrap()[1].rollback()
+
+        expect(FileMoveSpy).toHaveBeenCalledTimes(4)
+        expect(FileMakePublicSpy).toHaveBeenCalledTimes(2)
+        expect(FileMakePrivateSpy).toHaveBeenCalledTimes(2)
+
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('public/folder/file1.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(1)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('private/folder/file4.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(1)
+
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(3, new FileObject('public/folder/file4.txt'))
+        expect(FileMakePublicSpy).toHaveBeenNthCalledWith(2)
+        expect(FileMoveSpy).toHaveBeenNthCalledWith(4, new FileObject('temp/folder/file1.txt'))
+        expect(FileMakePrivateSpy).toHaveBeenNthCalledWith(2)
+      })
+
+      describe('should return error if rollback move fails', () => {
+        it('when moving to public folder', async () => {
+          let callCount = 0
+          FileMoveSpy.mockImplementation(async () => {
+            callCount++
+            if (callCount === 2) {
+              throw new Error('Failed to move file')
+            }
+          })
+          FileMakePublicSpy.mockImplementation(async () => {
+            throw new Error('Failed to make file public')
+          })
+
+          const fileService = createFileService()
+          const txResult = await fromRepositoryPromise(
+            fileService.$transaction(async (tx) => {
+              return tx.bulkMoveToPublicFolder(['temp/folder/file1.txt'])
+            })
+          )
+
+          expect(txResult.isErr()).toBe(true)
+          expect(txResult._unsafeUnwrapErr()).toEqual({
+            code: InternalErrorCode.FILE_ROLLBACK_FAILED,
+            message: 'Failed to move file temp/folder/file1.txt during rollback',
+          })
+
+          expect(FileMoveSpy).toHaveBeenCalledTimes(2)
+          expect(FileMoveSpy).toHaveBeenNthCalledWith(1, new FileObject('public/folder/file1.txt'))
+          expect(FileMoveSpy).toHaveBeenNthCalledWith(2, new FileObject('temp/folder/file1.txt'))
+
+          expect(FileMakePublicSpy).toHaveBeenCalledTimes(1)
+          expect(FileMakePrivateSpy).toHaveBeenCalledTimes(0)
+        })
+      })
+    })
+  })
+})

--- a/packages/api-common/src/services/prisma.test.ts
+++ b/packages/api-common/src/services/prisma.test.ts
@@ -1,0 +1,42 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+const constructorCalled = vi.fn()
+class PrismaClient {
+  constructor(args: any) {
+    constructorCalled(args)
+  }
+  $on() {}
+}
+
+vi.mock('@pple-today/database/prisma', () => ({
+  PrismaClient,
+}))
+
+describe('Prisma Service', async () => {
+  const { PrismaService } = await import('./prisma')
+
+  const loggerServiceMockData = {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }
+
+  beforeAll(() => {
+    constructorCalled.mockReset()
+  })
+
+  it('should be initialized without errors', () => {
+    const prisma = new PrismaService(loggerServiceMockData as any)
+
+    expect(prisma).toBeInstanceOf(PrismaService)
+    expect(constructorCalled).toHaveBeenCalledTimes(1)
+    expect(constructorCalled.mock.calls[0][0]).toEqual({
+      errorFormat: 'minimal',
+      log: [
+        { emit: 'event', level: 'error' },
+        { emit: 'event', level: 'warn' },
+      ],
+    })
+  })
+})

--- a/packages/api-common/src/utils/error.test.ts
+++ b/packages/api-common/src/utils/error.test.ts
@@ -1,0 +1,212 @@
+import { t } from 'elysia'
+import { Err, err as defaultErr } from 'neverthrow'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+import { createErrorSchema, err, tApiError } from './error'
+
+import { InternalErrorCode, InternalErrorCodeSchemas } from '../dtos'
+
+describe('Error utility', () => {
+  describe('tApiError', () => {
+    beforeAll(() => {
+      ;(InternalErrorCodeSchemas as any).TEST_DATA = {
+        status: 400,
+        data: t.Object({
+          testField: t.String(),
+        }),
+      }
+    })
+
+    afterAll(() => {
+      delete (InternalErrorCodeSchemas as any).TEST_DATA
+    })
+
+    it('should create a valid API error schema', () => {
+      const error = tApiError(InternalErrorCode.BAD_REQUEST)
+      expect(error).toEqual(
+        t.Object({
+          code: t.Literal(InternalErrorCode.BAD_REQUEST),
+          message: t.Optional(t.String()),
+          data: t.Optional(t.Unknown()),
+        })
+      )
+    })
+
+    it('should create a valid API error schema with data', () => {
+      const error = tApiError('TEST_DATA' as any)
+      expect(error).toEqual(
+        t.Object({
+          code: t.Literal('TEST_DATA'),
+          message: t.Optional(t.String()),
+          data: t.Object({
+            testField: t.String(),
+          }),
+        })
+      )
+    })
+  })
+
+  describe('tApiErrorResponse', () => {
+    beforeAll(() => {
+      ;(InternalErrorCodeSchemas as any).TEST_DATA = {
+        status: 400,
+        data: t.Object({
+          testField: t.String(),
+        }),
+      }
+    })
+
+    afterAll(() => {
+      delete (InternalErrorCodeSchemas as any).TEST_DATA
+    })
+
+    it('should create a valid API error response schema', () => {
+      const errorResponse = createErrorSchema(InternalErrorCode.BAD_REQUEST)
+      expect(errorResponse).toEqual({
+        400: t.Object({
+          error: t.Union([
+            t.Object({
+              code: t.Literal(InternalErrorCode.BAD_REQUEST),
+              message: t.Optional(t.String()),
+              data: t.Optional(t.Unknown()),
+            }),
+          ]),
+        }),
+      })
+    })
+
+    it('should create a valid API error response schema with multiple errors', () => {
+      const errorResponse = createErrorSchema(
+        InternalErrorCode.BAD_REQUEST,
+        InternalErrorCode.UNAUTHORIZED,
+        'TEST_DATA' as any
+      )
+      expect(errorResponse).toEqual({
+        400: t.Object({
+          error: t.Union([
+            t.Object({
+              code: t.Literal(InternalErrorCode.BAD_REQUEST),
+              message: t.Optional(t.String()),
+              data: t.Optional(t.Unknown()),
+            }),
+            t.Object({
+              code: t.Literal('TEST_DATA'),
+              message: t.Optional(t.String()),
+              data: t.Object({
+                testField: t.String(),
+              }),
+            }),
+          ]),
+        }),
+        401: t.Object({
+          error: t.Union([
+            t.Object({
+              code: t.Literal(InternalErrorCode.UNAUTHORIZED),
+              message: t.Optional(t.String()),
+              data: t.Optional(t.Unknown()),
+            }),
+          ]),
+        }),
+      })
+    })
+  })
+
+  describe('createErrorSchema', () => {
+    it('should group error schemas by their status codes', () => {
+      const testcases = [
+        {
+          input: [
+            InternalErrorCode.ABOUT_US_NOT_FOUND,
+            InternalErrorCode.ANNOUNCEMENT_NOT_FOUND,
+            InternalErrorCode.BAD_REQUEST,
+            InternalErrorCode.UNAUTHORIZED,
+          ],
+          output: {
+            400: t.Object({
+              error: t.Union([tApiError(InternalErrorCode.BAD_REQUEST)]),
+            }),
+            401: t.Object({
+              error: t.Union([tApiError(InternalErrorCode.UNAUTHORIZED)]),
+            }),
+            404: t.Object({
+              error: t.Union([
+                tApiError(InternalErrorCode.ABOUT_US_NOT_FOUND),
+                tApiError(InternalErrorCode.ANNOUNCEMENT_NOT_FOUND),
+              ]),
+            }),
+          },
+        },
+        {
+          input: [
+            InternalErrorCode.FORBIDDEN,
+            InternalErrorCode.INTERNAL_SERVER_ERROR,
+            InternalErrorCode.VALIDATION_ERROR,
+          ],
+          output: {
+            403: t.Object({
+              error: t.Union([tApiError(InternalErrorCode.FORBIDDEN)]),
+            }),
+            422: t.Object({ error: t.Union([tApiError(InternalErrorCode.VALIDATION_ERROR)]) }),
+            500: t.Object({ error: t.Union([tApiError(InternalErrorCode.INTERNAL_SERVER_ERROR)]) }),
+          },
+        },
+        {
+          input: [],
+          output: {},
+        },
+        {
+          input: [
+            InternalErrorCode.TOPIC_CANNOT_FOLLOW_DRAFT,
+            InternalErrorCode.TOPIC_ALREADY_FOLLOWED,
+            InternalErrorCode.TOPIC_CANNOT_FOLLOW_DRAFT,
+          ],
+          output: {
+            409: t.Object({
+              error: t.Union([
+                tApiError(InternalErrorCode.TOPIC_CANNOT_FOLLOW_DRAFT),
+                tApiError(InternalErrorCode.TOPIC_ALREADY_FOLLOWED),
+                tApiError(InternalErrorCode.TOPIC_CANNOT_FOLLOW_DRAFT),
+              ]),
+            }),
+          },
+        },
+      ]
+
+      for (const testcase of testcases) {
+        const result = createErrorSchema(...(testcase.input as any))
+        expect(result).toStrictEqual(testcase.output)
+      }
+    })
+  })
+
+  describe('err', () => {
+    it('should create an Err object', () => {
+      const error = {
+        message: 'Test error',
+        code: InternalErrorCode.BAD_REQUEST,
+      }
+      const result = err(error)
+
+      expect(result).toBeInstanceOf(Err)
+      expect(result.error).toBe(error)
+      expect(result.error).toHaveProperty('stack')
+    })
+
+    it('should not override stack if already present', () => {
+      const error = new Error('Test error with stack')
+      error.stack = 'Custom stack trace'
+      const result = err(error)
+
+      expect(result.error.stack).toBe('Custom stack trace')
+    })
+
+    it('should handle Err objects correctly', () => {
+      const errorBody = new Error('Test error body')
+
+      const originalErr = defaultErr(errorBody)
+      const result = err(originalErr)
+
+      expect(result.error).toBe(errorBody)
+    })
+  })
+})

--- a/packages/api-common/src/utils/error.test.ts
+++ b/packages/api-common/src/utils/error.test.ts
@@ -5,22 +5,21 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { createErrorSchema, err, tApiError } from './error'
 
 import { InternalErrorCode, InternalErrorCodeSchemas } from '../dtos'
+beforeAll(() => {
+  ;(InternalErrorCodeSchemas as any).TEST_DATA = {
+    status: 400,
+    data: t.Object({
+      testField: t.String(),
+    }),
+  }
+})
+
+afterAll(() => {
+  delete (InternalErrorCodeSchemas as any).TEST_DATA
+})
 
 describe('Error utility', () => {
   describe('tApiError', () => {
-    beforeAll(() => {
-      ;(InternalErrorCodeSchemas as any).TEST_DATA = {
-        status: 400,
-        data: t.Object({
-          testField: t.String(),
-        }),
-      }
-    })
-
-    afterAll(() => {
-      delete (InternalErrorCodeSchemas as any).TEST_DATA
-    })
-
     it('should create a valid API error schema', () => {
       const error = tApiError(InternalErrorCode.BAD_REQUEST)
       expect(error).toEqual(
@@ -47,19 +46,6 @@ describe('Error utility', () => {
   })
 
   describe('tApiErrorResponse', () => {
-    beforeAll(() => {
-      ;(InternalErrorCodeSchemas as any).TEST_DATA = {
-        status: 400,
-        data: t.Object({
-          testField: t.String(),
-        }),
-      }
-    })
-
-    afterAll(() => {
-      delete (InternalErrorCodeSchemas as any).TEST_DATA
-    })
-
     it('should create a valid API error response schema', () => {
       const errorResponse = createErrorSchema(InternalErrorCode.BAD_REQUEST)
       expect(errorResponse).toEqual({

--- a/packages/api-common/src/utils/error.ts
+++ b/packages/api-common/src/utils/error.ts
@@ -124,12 +124,7 @@ export function err<E extends object>(_err: E | Err<never, E>): Err<never, E> {
 export const fromRepositoryPromise = async <T>(
   promise: Promise<T> | (() => Promise<T>)
 ): Promise<Result<WithoutErr<T>, RawPrismaError | ExtractExplicitErr<T>>> => {
-  let promiseEntry
-  if (typeof promise === 'function') {
-    promiseEntry = promise()
-  } else {
-    promiseEntry = promise
-  }
+  const promiseEntry = typeof promise === 'function' ? promise() : promise
 
   try {
     const result = await promiseEntry

--- a/packages/api-common/src/utils/file.test.ts
+++ b/packages/api-common/src/utils/file.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { getFileName, getFilePath, MIME_TYPE_TO_EXTENSION } from './file'
+
+describe('File utility', () => {
+  describe('getFileName', () => {
+    it('should correctly return the filename', () => {
+      const filePath = 'http://example.com/path/to/file.txt'
+      const fileName = getFileName(filePath)
+
+      expect(fileName).toStrictEqual('file.txt')
+    })
+
+    it('should return only the filename without query params', () => {
+      const filePath = 'http://example.com/path/to/file.txt?version=1.2.3'
+      const fileName = getFileName(filePath)
+
+      expect(fileName).toStrictEqual('file.txt')
+    })
+  })
+
+  describe('getFilePath', () => {
+    it('should correctly return the file path without leading slash', () => {
+      const fullPath = 'path/to/file.txt'
+      const filePath = getFilePath(fullPath)
+
+      expect(filePath).toStrictEqual('to/file.txt')
+    })
+  })
+
+  describe('MIME_TYPE_TO_EXTENSION', () => {
+    it('should have correct mappings for MIME types to file extensions', () => {
+      expect(MIME_TYPE_TO_EXTENSION['image/png']).toBe('png')
+      expect(MIME_TYPE_TO_EXTENSION['image/jpeg']).toBe('jpg')
+      expect(MIME_TYPE_TO_EXTENSION['image/webp']).toBe('webp')
+      expect(MIME_TYPE_TO_EXTENSION['application/pdf']).toBe('pdf')
+      expect(MIME_TYPE_TO_EXTENSION['application/msword']).toBe('doc')
+      expect(
+        MIME_TYPE_TO_EXTENSION[
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+        ]
+      ).toBe('docx')
+      expect(MIME_TYPE_TO_EXTENSION['application/vnd.ms-excel']).toBe('xls')
+      expect(
+        MIME_TYPE_TO_EXTENSION['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet']
+      ).toBe('xlsx')
+      expect(MIME_TYPE_TO_EXTENSION['application/vnd.ms-powerpoint']).toBe('ppt')
+      expect(
+        MIME_TYPE_TO_EXTENSION[
+          'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+        ]
+      ).toBe('pptx')
+    })
+  })
+})

--- a/packages/api-common/src/utils/prisma.test.ts
+++ b/packages/api-common/src/utils/prisma.test.ts
@@ -1,0 +1,92 @@
+import { PrismaClientKnownRequestError } from '@pple-today/database/prisma/runtime/client'
+import { describe, expect, it } from 'vitest'
+
+import { resolvePrismaError } from './prisma'
+
+describe('Prisma utility', () => {
+  describe('resolvePrismaError', async () => {
+    it('should return a mapped error for known prisma error codes', () => {
+      const knownErrors = [
+        new PrismaClientKnownRequestError('Unique constraint failed', {
+          code: 'P2002',
+          clientVersion: '4.15.0',
+        }),
+        new PrismaClientKnownRequestError('Foreign key constraint failed', {
+          code: 'P2003',
+          clientVersion: '4.15.0',
+        }),
+        new PrismaClientKnownRequestError('Invalid input', {
+          code: 'P2016',
+          clientVersion: '4.15.0',
+        }),
+        new PrismaClientKnownRequestError('Model not connect', {
+          code: 'P2017',
+          clientVersion: '4.15.0',
+        }),
+        new PrismaClientKnownRequestError('Record not found', {
+          code: 'P2025',
+          clientVersion: '4.15.0',
+        }),
+      ]
+
+      const expectedOutputs = [
+        {
+          code: 'UNIQUE_CONSTRAINT_FAILED',
+          originalError: knownErrors[0],
+          message: 'Unique constraint failed',
+        },
+        {
+          code: 'FOREIGN_KEY_CONSTRAINT_FAILED',
+          originalError: knownErrors[1],
+          message: 'Foreign key constraint failed',
+        },
+        {
+          code: 'INVALID_INPUT',
+          originalError: knownErrors[2],
+          message: 'Invalid input',
+        },
+        {
+          code: 'MODEL_NOT_CONNECT',
+          originalError: knownErrors[3],
+          message: 'Model not connect',
+        },
+        {
+          code: 'RECORD_NOT_FOUND',
+          originalError: knownErrors[4],
+          message: 'Record not found',
+        },
+      ]
+
+      for (let i = 0; i < knownErrors.length; i++) {
+        const resolvedError = resolvePrismaError(knownErrors[i])
+
+        expect(resolvedError).toStrictEqual(expectedOutputs[i])
+      }
+    })
+    it('should return a default error for unknown prisma error codes', () => {
+      const unknownError = new PrismaClientKnownRequestError('Unknown error', {
+        code: 'P9999',
+        clientVersion: '4.15.0',
+      })
+
+      const resolvedError = resolvePrismaError(unknownError)
+
+      expect(resolvedError).toStrictEqual({
+        code: 'UNKNOWN_ERROR',
+        originalError: unknownError,
+        message: 'Unknown error',
+      })
+    })
+    it('should return a default error for non-prisma errors', () => {
+      const nonPrismaError = new Error('Some random error')
+
+      const resolvedError = resolvePrismaError(nonPrismaError)
+
+      expect(resolvedError).toStrictEqual({
+        code: 'UNKNOWN_ERROR',
+        originalError: nonPrismaError,
+        message: 'An unknown error occurred',
+      })
+    })
+  })
+})

--- a/packages/api-common/vitest.config.ts
+++ b/packages/api-common/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.test.ts'],
+    exclude: ['node_modules', 'dist', 'build', 'coverage'],
+    environment: 'node',
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -533,6 +533,9 @@ importers:
       type-fest:
         specifier: ^4.41.0
         version: 4.41.0
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.3.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
 
   packages/database:
     dependencies:
@@ -12294,7 +12297,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.3.1
+      '@types/node': 22.15.3
       '@types/yargs': 15.0.19
       chalk: 4.1.2
     optional: true
@@ -14731,6 +14734,14 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 7.0.2(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+
+  '@vitest/mocker@3.2.4(vite@7.0.2(@types/node@24.3.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.0.2(@types/node@24.3.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -21353,6 +21364,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@3.2.4(@types/node@24.3.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.1
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.3.5(@types/node@24.3.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.3.5(@types/node@20.19.6)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)):
     dependencies:
       debug: 4.4.1
@@ -21398,6 +21430,23 @@ snapshots:
       tsx: 4.20.3
       yaml: 2.8.0
 
+  vite@6.3.5(@types/node@24.3.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      esbuild: 0.25.5
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.6
+      rollup: 4.44.2
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 24.3.1
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      lightningcss: 1.30.1
+      terser: 5.39.0
+      tsx: 4.20.3
+      yaml: 2.8.0
+
   vite@7.0.2(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.5
@@ -21408,6 +21457,23 @@ snapshots:
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 22.15.3
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      lightningcss: 1.30.1
+      terser: 5.39.0
+      tsx: 4.20.3
+      yaml: 2.8.0
+
+  vite@7.0.2(@types/node@24.3.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      esbuild: 0.25.5
+      fdir: 6.4.6(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.6
+      rollup: 4.44.2
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 24.3.1
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.30.1
@@ -21446,6 +21512,48 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.15.3
+      jsdom: 20.0.3
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/node@24.3.1)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.0.2(@types/node@24.3.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.0
+      debug: 4.4.1
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.0.2(@types/node@24.3.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      vite-node: 3.2.4(@types/node@24.3.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.3.1
       jsdom: 20.0.3
     transitivePeerDependencies:
       - jiti

--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,10 @@
       "dependsOn": ["^codegen"],
       "outputs": ["__generated__/**", ".react-router/**"]
     },
+    "test": {
+      "dependsOn": ["codegen"],
+      "outputs": []
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
# Summary

- Fix file service transaction that does not rollback after return neverthrow error
- Add unit test suite for api-common package

# Screenshots/Video

# Steps to Test

1. Please run `pnpm test` to see the result

# Checklist

- [x] Add Changeset
- [x] Add Linear ID in PR title
- [x] Perform Manual Testing

> [!NOTE]
