### PR TITLE
[PPLE-404] Rollback register logic and add official user to default followings

### DIFF
--- a/.changeset/clean-birds-see.md
+++ b/.changeset/clean-birds-see.md
@@ -1,0 +1,6 @@
+---
+'@api/backoffice': patch
+'@pple-today/database': patch
+---
+
+[[PPLE-404] [API] Rollback register logic and add official user to default following](https://linear.app/snts/issue/PPLE-404/api-rollback-register-logic-and-add-official-user-to-default-following)

--- a/apps-api/backoffice/src/modules/auth/repository.ts
+++ b/apps-api/backoffice/src/modules/auth/repository.ts
@@ -19,6 +19,7 @@ export class AuthRepository {
     const findOfficialResult = await fromRepositoryPromise(
       this.prismaService.user.findFirst({
         where: { roles: { every: { role: 'official' } } },
+        select: { id: true },
       })
     )
 

--- a/apps-api/backoffice/src/modules/auth/repository.ts
+++ b/apps-api/backoffice/src/modules/auth/repository.ts
@@ -18,7 +18,7 @@ export class AuthRepository {
 
     const findOfficialResult = await fromRepositoryPromise(
       this.prismaService.user.findFirst({
-        where: { roles: { some: { role: 'official' } } },
+        where: { roles: { every: { role: 'official' } } },
       })
     )
 

--- a/packages/database/prisma/seeds/seed.prod.ts
+++ b/packages/database/prisma/seeds/seed.prod.ts
@@ -47,7 +47,7 @@ const prisma = new PrismaClient({
   adapter,
 })
 
-const OFFICIAL_USER_ID = 'pple-official-page'
+const OFFICIAL_USER_ID = 'pple-official-user'
 
 const seedAddresses = async (addresses: any) => {
   for (const { province, district, subDistrict, postalCode } of addresses) {

--- a/packages/database/prisma/seeds/seed.recommend.ts
+++ b/packages/database/prisma/seeds/seed.recommend.ts
@@ -45,8 +45,8 @@ const seedUsers = async () => {
   })
   await prisma.user.create({
     data: {
-      id: `official-user`,
-      name: `official-user@example.com`,
+      id: `pple-official-user`,
+      name: `pple-official-user@example.com`,
       phoneNumber: Crypto.randomUUID().slice(0, 15),
     },
   })
@@ -166,7 +166,7 @@ const seedFeedItems = async () => {
           await prisma.feedItem.create({
             data: {
               id: `feeditem-${i * NUMBER_OF_FEED_ITEMS_PER_USER + j + 1}`,
-              authorId: `official-user`,
+              authorId: `pple-official-user`,
               type: 'POLL',
               poll: {
                 create: {
@@ -193,7 +193,7 @@ const seedFeedItems = async () => {
           await prisma.feedItem.create({
             data: {
               id: `feeditem-${i * NUMBER_OF_FEED_ITEMS_PER_USER + j + 1}`,
-              authorId: `official-user`,
+              authorId: `pple-official-user`,
               type: 'ANNOUNCEMENT',
               announcement: {
                 create: {


### PR DESCRIPTION
# Summary

- Rollback register logic
- Add official user to default followings

# Screenshots/Video

<img width="1392" height="470" alt="image" src="https://github.com/user-attachments/assets/a7da7544-b694-4708-9909-4ba5e8734dce" />

<img width="690" height="183" alt="image" src="https://github.com/user-attachments/assets/aeb29a18-b980-42c5-9e2f-f1adddff7c05" />

# Steps to Test

1. Please visit `http://localhost:2000` and register new user using `http://localhost:2000/auth/register`
2. Then using `http://localhost:2000/profile/follow` which should return official user 

# Checklist

- [x] Add Changeset
- [x] Add Linear ID in PR title
- [x] Perform Manual Testing

> [!NOTE]
