### PR TITLE
[PPLE-392] Filter only creator account to appear in search results

### DIFF
--- a/.changeset/tall-peas-win.md
+++ b/.changeset/tall-peas-win.md
@@ -1,0 +1,5 @@
+---
+'@api/backoffice': patch
+---
+
+[[PPLE-392] [API] Only creator accounts can be searched](https://linear.app/snts/issue/PPLE-392/api-only-creator-accounts-can-be-searched)

--- a/apps-api/backoffice/src/modules/search/repository.ts
+++ b/apps-api/backoffice/src/modules/search/repository.ts
@@ -230,8 +230,10 @@ export class SearchRepository {
             mode: 'insensitive',
           },
           roles: {
-            none: {
-              role: 'official',
+            some: {
+              role: {
+                in: ['pple-ad:mp', 'pple-ad:hq'],
+              },
             },
           },
         },

--- a/packages/database/prisma/migrations/20251001083350_add_index_for_user_role/migration.sql
+++ b/packages/database/prisma/migrations/20251001083350_add_index_for_user_role/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "UserRole_role_idx" ON "public"."UserRole"("role");

--- a/packages/database/prisma/models/user.prisma
+++ b/packages/database/prisma/models/user.prisma
@@ -47,6 +47,7 @@ model UserRole {
     user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
     @@id([userId, role])
+    @@index([role])
 }
 
 model AdminUser {


### PR DESCRIPTION
# Summary

- Filter only creator account to appear in search results

# Screenshots/Video

<img width="696" height="203" alt="image" src="https://github.com/user-attachments/assets/7f1136f3-baa5-40a7-a93c-9c96bb9e11cd" />

<img width="380" height="81" alt="image" src="https://github.com/user-attachments/assets/dd720438-b73e-449d-b386-3e44525cbb4e" />

# Steps to Test

1. Please add `pple-ad:mp` or `pple-ad:hq` in `UserRole`
2. Visit `http://localhost:2000` and use search endpoint to query user
3. Returned result should include both of them

# Checklist

- [x] Add Changeset
- [x] Add Linear ID in PR title
- [x] Perform Manual Testing

> [!NOTE]
