### PR TITLE
Add Firebase Analytics screen tracking and update mini app layout

### DIFF
--- a/.changeset/eight-moons-look.md
+++ b/.changeset/eight-moons-look.md
@@ -1,0 +1,6 @@
+---
+"@client/mobile": patch
+"@api/backoffice": patch
+---
+
+Add Firebase Analytics screen tracking and update mini app layout

--- a/apps-api/backoffice/src/modules/mini-app/index.ts
+++ b/apps-api/backoffice/src/modules/mini-app/index.ts
@@ -1,6 +1,6 @@
 import { InternalErrorCode } from '@pple-today/api-common/dtos'
 import { createErrorSchema, mapErrorCodeToResponse } from '@pple-today/api-common/utils'
-import Elysia from 'elysia'
+import Elysia, { t } from 'elysia'
 
 import { ListMiniAppsResponse } from './models'
 import { MiniAppServicePlugin } from './services'
@@ -11,8 +11,9 @@ export const MiniAppController = new Elysia({ prefix: '/mini-app', tags: ['Mini 
   .use([AuthGuardPlugin, MiniAppServicePlugin])
   .get(
     '/',
-    async ({ status, miniAppService, user }) => {
-      const miniApps = await miniAppService.listMiniApps(user.roles)
+    async ({ query, status, miniAppService, user }) => {
+      const roles = query.role ? [query.role] : user.roles
+      const miniApps = await miniAppService.listMiniApps(roles)
 
       if (miniApps.isErr()) {
         return mapErrorCodeToResponse(miniApps.error, status)
@@ -22,6 +23,9 @@ export const MiniAppController = new Elysia({ prefix: '/mini-app', tags: ['Mini 
     },
     {
       requiredLocalUser: true,
+      query: t.Object({
+        role: t.Optional(t.String()),
+      }),
       detail: {
         summary: 'List Mini Apps',
         description: 'Retrieve the list of mini apps',

--- a/apps-client/mobile/app.config.ts
+++ b/apps-client/mobile/app.config.ts
@@ -66,7 +66,7 @@ export default {
 
             // https://github.com/invertase/react-native-firebase/issues/8657#issuecomment-3309893085
             useFrameworks: 'static',
-            forceStaticLinking: ['RNFBApp', 'RNFBMessaging'],
+            forceStaticLinking: ['RNFBApp', 'RNFBMessaging', 'RNFBAnalytics'],
           },
           android: {
             compileSdkVersion: 35,

--- a/apps-client/mobile/app.config.ts
+++ b/apps-client/mobile/app.config.ts
@@ -66,7 +66,7 @@ export default {
 
             // https://github.com/invertase/react-native-firebase/issues/8657#issuecomment-3309893085
             useFrameworks: 'static',
-            forceStaticLinking: ['RNFBApp', 'RNFBMessaging', 'RNFBAnalytics'],
+            forceStaticLinking: ['RNFBApp', 'RNFBMessaging', 'RNFBAnalytics', 'RNFBRemoteConfig'],
           },
           android: {
             compileSdkVersion: 35,

--- a/apps-client/mobile/app/(tabs)/(activity)/activity.tsx
+++ b/apps-client/mobile/app/(tabs)/(activity)/activity.tsx
@@ -1,10 +1,13 @@
 import React, { useCallback, useEffect, useMemo } from 'react'
-import { View } from 'react-native'
-import Animated from 'react-native-reanimated'
+import { Pressable, PressableProps, View } from 'react-native'
+import Animated, { useSharedValue, withTiming } from 'react-native-reanimated'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import { QUERY_KEY_SYMBOL } from '@pple-today/api-client'
+import { BottomSheetModal, BottomSheetView } from '@pple-today/ui/bottom-sheet/index'
 import { Button } from '@pple-today/ui/button'
 import { Icon } from '@pple-today/ui/icon'
+import { cn } from '@pple-today/ui/lib/utils'
 import { Skeleton } from '@pple-today/ui/skeleton'
 import { Text } from '@pple-today/ui/text'
 import { H1, H2, H3 } from '@pple-today/ui/typography'
@@ -16,20 +19,32 @@ import {
 } from '@tanstack/react-query'
 import dayjs from 'dayjs'
 import { Image } from 'expo-image'
-import { Link } from 'expo-router'
+import * as Linking from 'expo-linking'
+import { Link, useRouter } from 'expo-router'
 import * as WebBrowser from 'expo-web-browser'
 import {
   ArrowRightIcon,
   CalendarHeartIcon,
   CalendarIcon,
   CircleArrowRightIcon,
+  CircleChevronRightIcon,
+  GlobeIcon,
   HandshakeIcon,
+  InfoIcon,
+  LandmarkIcon,
   ListTodoIcon,
+  MailIcon,
+  MegaphoneIcon,
+  PhoneIcon,
   TicketIcon,
 } from 'lucide-react-native'
 
 import { Event, FeedItem, FeedItemPoll, ListPollsResponse } from '@api/backoffice/app'
+import ContactMail from '@app/assets/contact-mail.svg'
+import Personal from '@app/assets/personal.svg'
+import PPLEIcon from '@app/assets/pple-icon.svg'
 import { ActivityCard, ActivityCardSkeleton } from '@app/components/activity/activity-card'
+import { AnnouncementCard, AnnouncementCardSkeleton } from '@app/components/announcement'
 import { FeedCard, FeedCardSkeleton } from '@app/components/feed/feed-card'
 import { RefreshControl } from '@app/components/refresh-control'
 import { SafeAreaLayout } from '@app/components/safe-area-layout'
@@ -61,8 +76,16 @@ export default function ActivityPage() {
                 กิจกรรมจากพรรคประชาชน
               </Text>
             </View>
+            <View className="py-4">
+              <AnnouncementSection />
+            </View>
             <RecentActivity />
           </>
+        }
+        ListFooterExtraComponent={
+          <View className="py-4">
+            <InformationSection />
+          </View>
         }
       />
     </SafeAreaLayout>
@@ -210,7 +233,10 @@ function RecentActivity() {
   )
 }
 
-function PollFeedSection(props: { ListHeaderComponent: React.ReactNode }) {
+function PollFeedSection(props: {
+  ListHeaderComponent: React.ReactNode
+  ListFooterExtraComponent?: React.ReactNode
+}) {
   const session = useSession()
 
   const listPollQuery = useInfiniteQuery({
@@ -257,10 +283,15 @@ function PollFeedSection(props: { ListHeaderComponent: React.ReactNode }) {
 
   const queryClient = useQueryClient()
   const onRefresh = React.useCallback(async () => {
-    await queryClient.resetQueries({ queryKey: [QUERY_KEY_SYMBOL, 'infinite', 'polls'] })
-    await queryClient.resetQueries({
-      queryKey: reactQueryClient.getQueryKey('/events'),
-    })
+    await Promise.all([
+      queryClient.resetQueries({ queryKey: [QUERY_KEY_SYMBOL, 'infinite', 'polls'] }),
+      queryClient.resetQueries({
+        queryKey: reactQueryClient.getQueryKey('/events'),
+      }),
+      queryClient.resetQueries({
+        queryKey: reactQueryClient.getQueryKey('/announcements'),
+      }),
+    ])
   }, [queryClient])
 
   const flatListRef = React.useRef<Animated.FlatList<any>>(null)
@@ -296,7 +327,10 @@ function PollFeedSection(props: { ListHeaderComponent: React.ReactNode }) {
       renderItem={renderFeedItem}
       onEndReached={onEndReached}
       ListFooterComponent={
-        session ? <PollFooter queryResult={listPollQuery} className="mx-4" /> : undefined
+        <>
+          {session && <PollFooter queryResult={listPollQuery} className="mx-4" />}
+          {props.ListFooterExtraComponent}
+        </>
       }
     />
   )
@@ -327,5 +361,266 @@ export function PollFooter({ queryResult, className }: PollFooterProps) {
     <View className="flex flex-col items-center justify-center py-6">
       <Text className="text-base-text-medium font-heading-semibold">ไม่มีแบบสอบถามเพิ่มเติม</Text>
     </View>
+  )
+}
+
+const AnnouncementSection = () => {
+  const router = useRouter()
+  const announcementsQuery = reactQueryClient.useQuery('/announcements', {
+    query: { limit: 3 },
+  })
+
+  const data = announcementsQuery.data?.announcements
+
+  const AnnouncementPreviewList = () => {
+    if (announcementsQuery.isLoading || !data) {
+      return (
+        <View className="my-3 gap-3">
+          <AnnouncementCardSkeleton className="w-full" />
+          <AnnouncementCardSkeleton className="w-full" />
+          <AnnouncementCardSkeleton className="w-full" />
+        </View>
+      )
+    }
+
+    return (
+      <View className="my-3 gap-3">
+        {data.map((item) => (
+          <AnnouncementCard
+            className="w-full"
+            key={item.id}
+            onPress={() => router.navigate(`/announcement/${item.id}`)}
+            id={item.id}
+            feedId={item.id}
+            title={item.title}
+            date={item.publishedAt.toString()}
+            type={item.type}
+          />
+        ))}
+        {data.length === 0 && (
+          <View className="flex flex-col items-center justify-center">
+            <Text className="text-base-text-medium font-heading-semibold">ยังไม่มีประกาศ</Text>
+          </View>
+        )}
+      </View>
+    )
+  }
+
+  return (
+    <View className="px-4">
+      <View className="flex flex-row justify-between items-center">
+        <View className="flex flex-row gap-2 items-center">
+          <Icon icon={MegaphoneIcon} size={32} className="text-base-primary-default" />
+          <H2 className="text-2xl font-heading-semibold text-base-text-high">ประกาศ</H2>
+        </View>
+        <View className="min-h-10">
+          {data && data.length > 0 && (
+            <Button variant="ghost" onPress={() => router.navigate('/announcement')}>
+              <Text>ดูเพิ่มเติม</Text>
+              <Icon icon={ArrowRightIcon} strokeWidth={2} />
+            </Button>
+          )}
+        </View>
+      </View>
+      <AnnouncementPreviewList />
+    </View>
+  )
+}
+
+const InformationSection = () => {
+  const bottomSheetModalRef = React.useRef<BottomSheetModal>(null)
+  const onOpen = () => {
+    bottomSheetModalRef.current?.present()
+  }
+
+  const insets = useSafeAreaInsets()
+
+  return (
+    <View className="px-4">
+      <View className="flex flex-row gap-2 items-center">
+        <View className="w-8 h-8 flex items-center justify-center">
+          <Icon icon={InfoIcon} size={32} className="text-base-primary-default" />
+        </View>
+        <H2 className="text-2xl font-heading-semibold text-base-text-high">ข้อมูลพรรคประชาชน</H2>
+      </View>
+      <View className="mt-4 gap-y-4">
+        <View className="flex flex-row gap-x-[12.5px]">
+          <InfoItem
+            onPress={() => WebBrowser.openBrowserAsync('https://peoplesparty.or.th/person/')}
+          >
+            <View className="flex justify-start flex-col flex-wrap">
+              <View className="flex flex-col mb-3 h-8 w-8 bg-base-secondary-default rounded-lg items-center justify-center">
+                <Personal width={24} height={24} color="white" />
+              </View>
+              <Text className="text-base font-heading-semibold w-full">บุคลากรของพรรค</Text>
+            </View>
+            <View className="flex-1 justify-end items-end">
+              <Icon
+                icon={CircleChevronRightIcon}
+                size={28}
+                strokeWidth={1}
+                className="text-foreground"
+              />
+            </View>
+          </InfoItem>
+          <InfoItem
+            onPress={() => WebBrowser.openBrowserAsync('https://peoplesparty.or.th/about/')}
+          >
+            <View className="flex justify-start flex-col flex-wrap">
+              <View className="flex flex-col mb-3 h-8 w-8 bg-base-primary-default rounded-lg items-center justify-center">
+                <PPLEIcon width={20} height={16} color="white" />
+              </View>
+              <Text className="text-base font-heading-semibold w-full">เกี่ยวกับพรรคประชาชน</Text>
+            </View>
+            <View className="flex-1 justify-end items-end">
+              <Icon
+                icon={CircleChevronRightIcon}
+                size={28}
+                strokeWidth={1}
+                className="text-foreground"
+              />
+            </View>
+          </InfoItem>
+        </View>
+        <View className="flex flex-row gap-x-[12.5px]">
+          <InfoItem onPress={onOpen}>
+            <View className="flex justify-start flex-col flex-wrap">
+              <View className="flex flex-col mb-3 h-8 w-8 bg-violet-500 rounded-lg items-center justify-center">
+                <ContactMail width={24} height={24} color="white" />
+              </View>
+              <Text className="text-base font-heading-semibold w-full">ช่องทางการติดต่อ</Text>
+            </View>
+            <View className="flex-1 justify-end items-end">
+              <Icon
+                icon={CircleChevronRightIcon}
+                size={28}
+                strokeWidth={1}
+                className="text-foreground"
+              />
+            </View>
+            <BottomSheetModal ref={bottomSheetModalRef} bottomInset={insets.bottom}>
+              <BottomSheetView>
+                <View className="p-4 pb-0">
+                  <H3>ช่องทางการติดต่อ</H3>
+                </View>
+                <View className="p-4">
+                  <View className="w-full rounded-lg border border-base-outline-default p-4 bg-base-bg-default">
+                    <View className="gap-4">
+                      <View className="gap-2">
+                        <View className="flex flex-row justify-start items-center gap-1">
+                          <Icon
+                            icon={LandmarkIcon}
+                            size={16}
+                            strokeWidth={1}
+                            className="text-base-primary-default"
+                          />
+                          <Text className="text-base-text-high font-body-medium">สำนักงานใหญ่</Text>
+                        </View>
+                        <View className="gap-0.5">
+                          <Text className="font-body-light">เลขที่ 167 อาคารอนาคตใหม่ ชั้น 4</Text>
+                          <Text className="font-body-light">
+                            รามคำแหง 42 แขวงหัวหมาก เขต บางกะปิ
+                          </Text>
+                          <Text className="font-body-light">กรุงเทพมหานคร 10240</Text>
+                        </View>
+                      </View>
+                      <View className="gap-2">
+                        <View className="flex flex-row justify-start items-center gap-1">
+                          <Icon
+                            icon={PhoneIcon}
+                            size={16}
+                            strokeWidth={1}
+                            className="text-base-primary-default"
+                          />
+                          <Text className="text-base-text-high font-body-medium">เบอร์โทร</Text>
+                        </View>
+                        <Text className="font-body-light items-baseline">
+                          <Text
+                            onPress={() => Linking.openURL('tel:028215874')}
+                            className="underline font-body-light"
+                          >
+                            02-821-5874
+                          </Text>{' '}
+                          (จันทร์-ศุกร์ 10:00-18:00 น.)
+                        </Text>
+                      </View>
+                      <View className="gap-2">
+                        <View className="flex flex-row justify-start items-center gap-1">
+                          <Icon
+                            icon={MailIcon}
+                            size={16}
+                            strokeWidth={1}
+                            className="text-base-primary-default"
+                          />
+                          <Text className="text-base-text-high font-body-medium">อีเมล</Text>
+                        </View>
+                        <View className="gap-0.5 mb-10">
+                          <Text
+                            className="font-body-light underline"
+                            onPress={() =>
+                              Linking.openURL('mailto:office@peoplespartythailand.org')
+                            }
+                          >
+                            office@peoplespartythailand.org
+                          </Text>
+                          <Text className="font-body-light">PeoplesPartyThailand</Text>
+                          <Text className="font-body-light">@PPLEThailand</Text>
+                          <Text className="font-body-light">พรรคประชาชน - People&apos;s Party</Text>
+                        </View>
+                      </View>
+                    </View>
+                  </View>
+                </View>
+              </BottomSheetView>
+            </BottomSheetModal>
+          </InfoItem>
+          <InfoItem onPress={() => WebBrowser.openBrowserAsync('https://peoplesparty.or.th/')}>
+            <View className="flex justify-start flex-col flex-wrap">
+              <View className="flex flex-col mb-3 h-8 w-8 bg-blue-500 rounded-lg items-center justify-center">
+                <Icon icon={GlobeIcon} size={22} color="white" />
+              </View>
+              <Text className="text-base font-heading-semibold w-full">เว็บไซต์ทางการ</Text>
+            </View>
+            <View className="flex-1 justify-end items-end">
+              <Icon
+                icon={CircleChevronRightIcon}
+                size={28}
+                strokeWidth={1}
+                className="text-foreground"
+              />
+            </View>
+          </InfoItem>
+        </View>
+      </View>
+    </View>
+  )
+}
+
+interface InfoItemProps extends PressableProps {
+  children: React.ReactNode
+}
+
+const InfoItem = ({ children, ...props }: InfoItemProps) => {
+  const opacity = useSharedValue(1)
+  const onPressIn = () => {
+    opacity.value = withTiming(0.5, { duration: 150 })
+  }
+  const onPressOut = () => {
+    opacity.value = withTiming(1, { duration: 150 })
+  }
+  return (
+    <Pressable
+      onPressIn={onPressIn}
+      onPressOut={onPressOut}
+      {...props}
+      className={cn('flex-1', props.className)}
+    >
+      <Animated.View
+        style={{ opacity }}
+        className="p-4 flex flex-col justify-between min-h-[163px] bg-base-bg-white rounded-2xl border border-base-outline-default"
+      >
+        {children}
+      </Animated.View>
+    </Pressable>
   )
 }

--- a/apps-client/mobile/app/(tabs)/(official)/official.tsx
+++ b/apps-client/mobile/app/(tabs)/(official)/official.tsx
@@ -18,7 +18,7 @@ import { H1, H2 } from '@pple-today/ui/typography'
 import { useQueryClient } from '@tanstack/react-query'
 import { Image } from 'expo-image'
 import { useRouter } from 'expo-router'
-import { CircleChevronRightIcon, VoteIcon } from 'lucide-react-native'
+import { VoteIcon } from 'lucide-react-native'
 
 import Personal from '@app/assets/personal.svg'
 import PPLEIcon from '@app/assets/pple-icon.svg'
@@ -84,7 +84,7 @@ export default function OfficialPage() {
             แอปพลิเคชันจากพรรคประชาชน
           </Text>
         </View>
-        <View className="gap-3 py-4">
+        <View className="gap-3 py-4 flex-1">
           <ElectionSection />
           <MiniAppSection selectedRole={selectedRole} />
         </View>
@@ -137,14 +137,14 @@ const MiniAppSection = ({ selectedRole }: { selectedRole: Option | undefined }) 
     query: selectedRole?.value ? { role: selectedRole.value } : {},
   })
 
-  const miniAppGroupByTwo = useMemo(() => {
+  const miniAppGroupByThree = useMemo(() => {
     if (!miniAppData) {
       return []
     }
 
     const grouped: (typeof miniAppData)[] = []
-    for (let i = 0; i < miniAppData.length; i += 2) {
-      grouped.push(miniAppData.slice(i, i + 2))
+    for (let i = 0; i < miniAppData.length; i += 3) {
+      grouped.push(miniAppData.slice(i, i + 3))
     }
 
     return grouped
@@ -156,32 +156,38 @@ const MiniAppSection = ({ selectedRole }: { selectedRole: Option | undefined }) 
 
   return (
     <View className="px-4">
-      <View className="flex flex-col gap-4 mt-4 items-center">
-        {miniAppGroupByTwo.map((group, index) => (
-          <View key={index} className="flex flex-1 flex-row gap-4">
+      <View className="flex flex-col gap-4 mt-4">
+        {miniAppGroupByThree.map((group, index) => (
+          <View key={index} className="flex flex-row gap-4 w-full">
             {group.map((app) => (
-              <InfoItem key={app.slug} onPress={() => router.navigate(`/mini-app/${app.slug}`)}>
-                <View className="flex justify-start flex-col">
-                  <View className="flex flex-col mb-3 h-8 w-8 bg-base-secondary-default rounded-lg items-center justify-center">
-                    {app.iconUrl ? (
-                      <Image source={{ uri: app.iconUrl }} className="w-4 h-4" />
-                    ) : (
-                      <Personal width={16} height={16} color="white" />
-                    )}
+              <View key={app.slug} className="flex-1">
+                <InfoItem onPress={() => router.navigate(`/mini-app/${app.slug}`)}>
+                  <View className="flex justify-center items-center flex-col">
+                    <View className="flex flex-col mb-3 h-16 w-16 bg-base-secondary-default rounded-lg items-center justify-center">
+                      {app.iconUrl ? (
+                        <Image source={{ uri: app.iconUrl }} className="w-8 h-8" />
+                      ) : (
+                        <Personal width={32} height={32} color="white" />
+                      )}
+                    </View>
+                    <Text
+                      numberOfLines={2}
+                      className="text-xs font-heading-semibold w-full text-center"
+                    >
+                      {app.name}
+                    </Text>
                   </View>
-                  <Text className="text-base font-heading-semibold w-full">{app.name}</Text>
-                </View>
-                <View className="flex-1 justify-end items-end">
-                  <Icon
-                    icon={CircleChevronRightIcon}
-                    size={28}
-                    strokeWidth={1}
-                    className="text-foreground"
-                  />
-                </View>
-              </InfoItem>
+                </InfoItem>
+              </View>
             ))}
-            {group.length === 1 && <View className="flex-1" />}
+
+            {group.length === 1 && (
+              <>
+                <View className="flex-1" />
+                <View className="flex-1" />
+              </>
+            )}
+            {group.length === 2 && <View className="flex-1" />}
           </View>
         ))}
       </View>
@@ -208,10 +214,7 @@ const InfoItem = ({ children, ...props }: InfoItemProps) => {
       {...props}
       className={cn('flex-1', props.className)}
     >
-      <Animated.View
-        style={{ opacity }}
-        className="p-4 flex flex-col justify-between min-h-[163px] bg-base-bg-white rounded-2xl border border-base-outline-default"
-      >
+      <Animated.View style={{ opacity }} className="p-4 flex flex-col justify-between">
         {children}
       </Animated.View>
     </Pressable>

--- a/apps-client/mobile/app/(tabs)/(official)/official.tsx
+++ b/apps-client/mobile/app/(tabs)/(official)/official.tsx
@@ -1,10 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import { Pressable, PressableProps, ScrollView, View } from 'react-native'
 import Animated, { useSharedValue, withTiming } from 'react-native-reanimated'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
-import { BottomSheetModal, BottomSheetView } from '@pple-today/ui/bottom-sheet/index'
-import { Button } from '@pple-today/ui/button'
 import { Icon } from '@pple-today/ui/icon'
 import { cn } from '@pple-today/ui/lib/utils'
 import {
@@ -17,30 +14,14 @@ import {
 } from '@pple-today/ui/select'
 import { Slide, SlideIndicators, SlideItem, SlideScrollView } from '@pple-today/ui/slide'
 import { Text } from '@pple-today/ui/text'
-import { H1, H2, H3 } from '@pple-today/ui/typography'
+import { H1, H2 } from '@pple-today/ui/typography'
 import { useQueryClient } from '@tanstack/react-query'
 import { Image } from 'expo-image'
-import * as Linking from 'expo-linking'
 import { useRouter } from 'expo-router'
-import * as WebBrowser from 'expo-web-browser'
-import {
-  ArrowRightIcon,
-  CircleChevronRightIcon,
-  GlobeIcon,
-  InfoIcon,
-  LandmarkIcon,
-  MailIcon,
-  MegaphoneIcon,
-  PanelsTopLeftIcon,
-  PhoneIcon,
-  VoteIcon,
-} from 'lucide-react-native'
+import { CircleChevronRightIcon, VoteIcon } from 'lucide-react-native'
 
-import ContactMail from '@app/assets/contact-mail.svg'
 import Personal from '@app/assets/personal.svg'
 import PPLEIcon from '@app/assets/pple-icon.svg'
-import { UserAddressInfoSection } from '@app/components/address-info'
-import { AnnouncementCard, AnnouncementCardSkeleton } from '@app/components/announcement'
 import { ElectionCard } from '@app/components/election/election-card'
 import { RefreshControl } from '@app/components/refresh-control'
 import { SafeAreaLayout } from '@app/components/safe-area-layout'
@@ -50,15 +31,16 @@ import { getRoleName } from '@app/utils/get-role-name'
 
 import { useBottomTabOnPress } from '../_layout'
 
+const ALL_ROLES_OPTION: Option = { value: '', label: 'ทั้งหมด' }
+
 export default function OfficialPage() {
   const queryClient = useQueryClient()
+  const [selectedRole, setSelectedRole] = useState<Option | undefined>(ALL_ROLES_OPTION)
+  const profileQuery = reactQueryClient.useQuery('/profile/me', {})
   const onRefresh = useCallback(async () => {
     await Promise.all([
       queryClient.invalidateQueries({
         queryKey: reactQueryClient.getQueryKey('/elections'),
-      }),
-      queryClient.resetQueries({
-        queryKey: reactQueryClient.getQueryKey('/announcements'),
       }),
       queryClient.resetQueries({
         queryKey: reactQueryClient.getQueryKey('/mini-app'),
@@ -79,25 +61,32 @@ export default function OfficialPage() {
         refreshControl={<RefreshControl onRefresh={onRefresh} />}
       >
         <View className="flex flex-col p-4 bg-base-bg-white">
-          <View className="flex flex-row gap-2 items-center">
-            <Icon
-              icon={LandmarkIcon}
-              size={32}
-              strokeWidth={2}
-              className="text-base-primary-default"
-            />
-            <H1 className="text-3xl font-heading-semibold text-base-primary-default">ทางการ</H1>
+          <View className="flex flex-row gap-2 items-center justify-between">
+            <View className="flex flex-row gap-2 items-center">
+              <PPLEIcon width={35} height={30} />
+              <H1 className="text-3xl font-heading-semibold text-base-primary-default">แอป</H1>
+            </View>
+            {profileQuery.data && profileQuery.data.roles.length > 0 && (
+              <Select value={selectedRole} onValueChange={setSelectedRole}>
+                <SelectTrigger className="min-w-[120px]">
+                  <SelectValue placeholder="ทั้งหมด" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem label="ทั้งหมด" value="" />
+                  {profileQuery.data.roles.map((role) => (
+                    <SelectItem key={role} label={getRoleName([role])} value={role} />
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
           </View>
           <Text className="font-heading-regular text-base-text-medium">
-            ข้อมูลข่าวสารจากพรรคประชาชน
+            แอปพลิเคชันจากพรรคประชาชน
           </Text>
         </View>
-        <UserAddressInfoSection className="pb-4 bg-base-bg-white" />
         <View className="gap-3 py-4">
           <ElectionSection />
-          <AnnouncementSection />
-          <InformationSection />
-          <MiniAppSection />
+          <MiniAppSection selectedRole={selectedRole} />
         </View>
       </ScrollView>
     </SafeAreaLayout>
@@ -142,244 +131,8 @@ const ElectionSection = () => {
   )
 }
 
-const AnnouncementSection = () => {
+const MiniAppSection = ({ selectedRole }: { selectedRole: Option | undefined }) => {
   const router = useRouter()
-  const announcementsQuery = reactQueryClient.useQuery('/announcements', {
-    query: { limit: 3 },
-  })
-
-  const data = announcementsQuery.data?.announcements
-
-  const AnnouncementPreviewList = () => {
-    if (announcementsQuery.isLoading || !data) {
-      return (
-        <View className="my-3 gap-3">
-          <AnnouncementCardSkeleton className="w-full" />
-          <AnnouncementCardSkeleton className="w-full" />
-          <AnnouncementCardSkeleton className="w-full" />
-        </View>
-      )
-    }
-
-    return (
-      <View className="my-3 gap-3">
-        {data.map((item) => (
-          <AnnouncementCard
-            className="w-full"
-            key={item.id}
-            onPress={() => router.navigate(`/announcement/${item.id}`)}
-            id={item.id}
-            feedId={item.id}
-            title={item.title}
-            date={item.publishedAt.toString()}
-            type={item.type}
-          />
-        ))}
-        {data.length === 0 && (
-          <View className="flex flex-col items-center justify-center">
-            <Text className="text-base-text-medium font-heading-semibold">ยังไม่มีประกาศ</Text>
-          </View>
-        )}
-      </View>
-    )
-  }
-
-  return (
-    <View className="px-4">
-      <View className="flex flex-row justify-between items-center">
-        <View className="flex flex-row gap-2 items-center">
-          <Icon icon={MegaphoneIcon} size={32} className="text-base-primary-default" />
-          <H2 className="text-2xl font-heading-semibold text-base-text-high">ประกาศ</H2>
-        </View>
-        <View className="min-h-10">
-          {data && data.length > 0 && (
-            <Button variant="ghost" onPress={() => router.navigate('/announcement')}>
-              <Text>ดูเพิ่มเติม</Text>
-              <Icon icon={ArrowRightIcon} strokeWidth={2} />
-            </Button>
-          )}
-        </View>
-      </View>
-      <AnnouncementPreviewList />
-    </View>
-  )
-}
-
-const InformationSection = () => {
-  const bottomSheetModalRef = React.useRef<BottomSheetModal>(null)
-  const onOpen = () => {
-    bottomSheetModalRef.current?.present()
-  }
-
-  const insets = useSafeAreaInsets()
-
-  return (
-    <View className="px-4">
-      <View className="flex flex-row gap-2 items-center">
-        <View className="w-8 h-8 flex items-center justify-center">
-          <Icon icon={InfoIcon} size={32} className="text-base-primary-default" />
-        </View>
-        <H2 className="text-2xl font-heading-semibold text-base-text-high">ข้อมูลพรรคประชาชน</H2>
-      </View>
-      <View className="mt-4 gap-y-4">
-        <View className="flex flex-row gap-x-[12.5px]">
-          <InfoItem
-            onPress={() => WebBrowser.openBrowserAsync('https://peoplesparty.or.th/person/')}
-          >
-            <View className="flex justify-start flex-col flex-wrap">
-              <View className="flex flex-col mb-3 h-8 w-8 bg-base-secondary-default rounded-lg items-center justify-center">
-                <Personal width={24} height={24} color="white" />
-              </View>
-              <Text className="text-base font-heading-semibold w-full">บุคลากรของพรรค</Text>
-            </View>
-            <View className="flex-1 justify-end items-end">
-              <Icon
-                icon={CircleChevronRightIcon}
-                size={28}
-                strokeWidth={1}
-                className="text-foreground"
-              />
-            </View>
-          </InfoItem>
-          <InfoItem
-            onPress={() => WebBrowser.openBrowserAsync('https://peoplesparty.or.th/about/')}
-          >
-            <View className="flex justify-start flex-col flex-wrap">
-              <View className="flex flex-col mb-3 h-8 w-8 bg-base-primary-default rounded-lg items-center justify-center">
-                <PPLEIcon width={20} height={16} color="white" />
-              </View>
-              <Text className="text-base font-heading-semibold w-full">เกี่ยวกับพรรคประชาชน</Text>
-            </View>
-            <View className="flex-1 justify-end items-end">
-              <Icon
-                icon={CircleChevronRightIcon}
-                size={28}
-                strokeWidth={1}
-                className="text-foreground"
-              />
-            </View>
-          </InfoItem>
-        </View>
-        <View className="flex flex-row gap-x-[12.5px]">
-          <InfoItem onPress={onOpen}>
-            <View className="flex justify-start flex-col flex-wrap">
-              <View className="flex flex-col mb-3 h-8 w-8 bg-violet-500 rounded-lg items-center justify-center">
-                <ContactMail width={24} height={24} color="white" />
-              </View>
-              <Text className="text-base font-heading-semibold w-full">ช่องทางการติดต่อ</Text>
-            </View>
-            <View className="flex-1 justify-end items-end">
-              <Icon
-                icon={CircleChevronRightIcon}
-                size={28}
-                strokeWidth={1}
-                className="text-foreground"
-              />
-            </View>
-            <BottomSheetModal ref={bottomSheetModalRef} bottomInset={insets.bottom}>
-              <BottomSheetView>
-                <View className="p-4 pb-0">
-                  <H3>ช่องทางการติดต่อ</H3>
-                </View>
-                <View className="p-4">
-                  <View className="w-full rounded-lg border border-base-outline-default p-4 bg-base-bg-default">
-                    <View className="gap-4">
-                      <View className="gap-2">
-                        <View className="flex flex-row justify-start items-center gap-1">
-                          <Icon
-                            icon={LandmarkIcon}
-                            size={16}
-                            strokeWidth={1}
-                            className="text-base-primary-default"
-                          />
-                          <Text className="text-base-text-high font-body-medium">สำนักงานใหญ่</Text>
-                        </View>
-                        <View className="gap-0.5">
-                          <Text className="font-body-light">เลขที่ 167 อาคารอนาคตใหม่ ชั้น 4</Text>
-                          <Text className="font-body-light">
-                            รามคำแหง 42 แขวงหัวหมาก เขต บางกะปิ
-                          </Text>
-                          <Text className="font-body-light">กรุงเทพมหานคร 10240</Text>
-                        </View>
-                      </View>
-                      <View className="gap-2">
-                        <View className="flex flex-row justify-start items-center gap-1">
-                          <Icon
-                            icon={PhoneIcon}
-                            size={16}
-                            strokeWidth={1}
-                            className="text-base-primary-default"
-                          />
-                          <Text className="text-base-text-high font-body-medium">เบอร์โทร</Text>
-                        </View>
-                        <Text className="font-body-light items-baseline">
-                          <Text
-                            onPress={() => Linking.openURL('tel:028215874')}
-                            className="underline font-body-light"
-                          >
-                            02-821-5874
-                          </Text>{' '}
-                          (จันทร์-ศุกร์ 10:00-18:00 น.)
-                        </Text>
-                      </View>
-                      <View className="gap-2">
-                        <View className="flex flex-row justify-start items-center gap-1">
-                          <Icon
-                            icon={MailIcon}
-                            size={16}
-                            strokeWidth={1}
-                            className="text-base-primary-default"
-                          />
-                          <Text className="text-base-text-high font-body-medium">อีเมล</Text>
-                        </View>
-                        <View className="gap-0.5 mb-10">
-                          <Text
-                            className="font-body-light underline"
-                            onPress={() =>
-                              Linking.openURL('mailto:office@peoplespartythailand.org')
-                            }
-                          >
-                            office@peoplespartythailand.org
-                          </Text>
-                          <Text className="font-body-light">PeoplesPartyThailand</Text>
-                          <Text className="font-body-light">@PPLEThailand</Text>
-                          <Text className="font-body-light">พรรคประชาชน - People&apos;s Party</Text>
-                        </View>
-                      </View>
-                    </View>
-                  </View>
-                </View>
-              </BottomSheetView>
-            </BottomSheetModal>
-          </InfoItem>
-          <InfoItem onPress={() => WebBrowser.openBrowserAsync('https://peoplesparty.or.th/')}>
-            <View className="flex justify-start flex-col flex-wrap">
-              <View className="flex flex-col mb-3 h-8 w-8 bg-blue-500 rounded-lg items-center justify-center">
-                <Icon icon={GlobeIcon} size={22} color="white" />
-              </View>
-              <Text className="text-base font-heading-semibold w-full">เว็บไซต์ทางการ</Text>
-            </View>
-            <View className="flex-1 justify-end items-end">
-              <Icon
-                icon={CircleChevronRightIcon}
-                size={28}
-                strokeWidth={1}
-                className="text-foreground"
-              />
-            </View>
-          </InfoItem>
-        </View>
-      </View>
-    </View>
-  )
-}
-
-const ALL_ROLES_OPTION: Option = { value: '', label: 'ทั้งหมด' }
-
-const MiniAppSection = () => {
-  const router = useRouter()
-  const [selectedRole, setSelectedRole] = useState<Option | undefined>(ALL_ROLES_OPTION)
-  const profileQuery = reactQueryClient.useQuery('/profile/me', {})
   const { data: miniAppData } = reactQueryClient.useQuery('/mini-app', {
     query: selectedRole?.value ? { role: selectedRole.value } : {},
   })
@@ -403,27 +156,6 @@ const MiniAppSection = () => {
 
   return (
     <View className="px-4">
-      <View className="flex flex-row justify-between items-center">
-        <View className="flex flex-row gap-2 items-center">
-          <View className="w-8 h-8 flex items-center justify-center">
-            <Icon icon={PanelsTopLeftIcon} size={32} className="text-base-primary-default" />
-          </View>
-          <H2 className="text-2xl font-heading-semibold text-base-text-high">มินิแอปฯ</H2>
-        </View>
-        {profileQuery.data && profileQuery.data.roles.length > 0 && (
-          <Select value={selectedRole} onValueChange={setSelectedRole}>
-            <SelectTrigger className="min-w-[120px]">
-              <SelectValue placeholder="ทั้งหมด" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem label="ทั้งหมด" value="" />
-              {profileQuery.data.roles.map((role) => (
-                <SelectItem key={role} label={getRoleName([role])} value={role} />
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-      </View>
       <View className="flex flex-col gap-4 mt-4 items-center">
         {miniAppGroupByTwo.map((group, index) => (
           <View key={index} className="flex flex-1 flex-row gap-4">

--- a/apps-client/mobile/app/(tabs)/(official)/official.tsx
+++ b/apps-client/mobile/app/(tabs)/(official)/official.tsx
@@ -12,6 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@pple-today/ui/select'
+import { Skeleton } from '@pple-today/ui/skeleton'
 import { Slide, SlideIndicators, SlideItem, SlideScrollView } from '@pple-today/ui/slide'
 import { Text } from '@pple-today/ui/text'
 import { H1, H2 } from '@pple-today/ui/typography'
@@ -20,7 +21,6 @@ import { Image } from 'expo-image'
 import { useRouter } from 'expo-router'
 import { VoteIcon } from 'lucide-react-native'
 
-import Personal from '@app/assets/personal.svg'
 import PPLEIcon from '@app/assets/pple-icon.svg'
 import { ElectionCard } from '@app/components/election/election-card'
 import { RefreshControl } from '@app/components/refresh-control'
@@ -133,7 +133,7 @@ const ElectionSection = () => {
 
 const MiniAppSection = ({ selectedRole }: { selectedRole: Option | undefined }) => {
   const router = useRouter()
-  const { data: miniAppData } = reactQueryClient.useQuery('/mini-app', {
+  const { data: miniAppData, isLoading } = reactQueryClient.useQuery('/mini-app', {
     query: selectedRole?.value ? { role: selectedRole.value } : {},
   })
 
@@ -150,6 +150,10 @@ const MiniAppSection = ({ selectedRole }: { selectedRole: Option | undefined }) 
     return grouped
   }, [miniAppData])
 
+  if (isLoading) {
+    return <MiniAppSkeleton />
+  }
+
   if (!miniAppData || miniAppData.length === 0) {
     return null
   }
@@ -163,12 +167,13 @@ const MiniAppSection = ({ selectedRole }: { selectedRole: Option | undefined }) 
               <View key={app.slug} className="flex-1">
                 <InfoItem onPress={() => router.navigate(`/mini-app/${app.slug}`)}>
                   <View className="flex justify-center items-center flex-col">
-                    <View className="flex flex-col mb-3 h-16 w-16 bg-base-secondary-default rounded-lg items-center justify-center">
-                      {app.iconUrl ? (
-                        <Image source={{ uri: app.iconUrl }} className="w-8 h-8" />
-                      ) : (
-                        <Personal width={32} height={32} color="white" />
+                    <View
+                      className={cn(
+                        'flex flex-col mb-3 h-16 w-16 rounded-lg items-center justify-center overflow-hidden border border-base-outline-default',
+                        isImageUri(app.iconUrl) ? 'bg-transparent' : 'bg-base-secondary-default'
                       )}
+                    >
+                      <MiniAppIcon iconUrl={app.iconUrl} />
                     </View>
                     <Text
                       numberOfLines={2}
@@ -199,6 +204,18 @@ interface InfoItemProps extends PressableProps {
   children: React.ReactNode
 }
 
+function isImageUri(url: string | null): url is string {
+  if (!url) return false
+  return url.startsWith('https://') || url.startsWith('data:image/')
+}
+
+function MiniAppIcon({ iconUrl }: { iconUrl: string | null }) {
+  if (isImageUri(iconUrl)) {
+    return <Image source={{ uri: iconUrl }} contentFit="contain" className="w-16 h-16" />
+  }
+  return <Icon icon={PPLEIcon} width={32} height={32} className="text-primary" />
+}
+
 const InfoItem = ({ children, ...props }: InfoItemProps) => {
   const opacity = useSharedValue(1)
   const onPressIn = () => {
@@ -214,9 +231,32 @@ const InfoItem = ({ children, ...props }: InfoItemProps) => {
       {...props}
       className={cn('flex-1', props.className)}
     >
-      <Animated.View style={{ opacity }} className="p-4 flex flex-col justify-between">
+      <Animated.View style={{ opacity }} className="p-4 flex flex-col items-center">
         {children}
       </Animated.View>
     </Pressable>
+  )
+}
+
+function MiniAppItemSkeleton() {
+  return (
+    <View className="flex-1 p-4 flex justify-center items-center flex-col">
+      <Skeleton className="mb-3 h-16 w-16 rounded-lg bg-base-bg-white" />
+      <Skeleton className="h-3 w-12 rounded bg-base-bg-white" />
+    </View>
+  )
+}
+
+function MiniAppSkeleton() {
+  return (
+    <View className="px-4">
+      <View className="flex flex-col gap-4">
+        <View className="flex flex-row gap-4 w-full">
+          <MiniAppItemSkeleton />
+          <View className="flex-1" />
+          <View className="flex-1" />
+        </View>
+      </View>
+    </View>
   )
 }

--- a/apps-client/mobile/app/(tabs)/(official)/official.tsx
+++ b/apps-client/mobile/app/(tabs)/(official)/official.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { Pressable, PressableProps, ScrollView, View } from 'react-native'
 import Animated, { useSharedValue, withTiming } from 'react-native-reanimated'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -7,6 +7,14 @@ import { BottomSheetModal, BottomSheetView } from '@pple-today/ui/bottom-sheet/i
 import { Button } from '@pple-today/ui/button'
 import { Icon } from '@pple-today/ui/icon'
 import { cn } from '@pple-today/ui/lib/utils'
+import {
+  Option,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@pple-today/ui/select'
 import { Slide, SlideIndicators, SlideItem, SlideScrollView } from '@pple-today/ui/slide'
 import { Text } from '@pple-today/ui/text'
 import { H1, H2, H3 } from '@pple-today/ui/typography'
@@ -38,6 +46,7 @@ import { RefreshControl } from '@app/components/refresh-control'
 import { SafeAreaLayout } from '@app/components/safe-area-layout'
 import { reactQueryClient } from '@app/libs/api-client'
 import { useSession } from '@app/libs/auth'
+import { getRoleName } from '@app/utils/get-role-name'
 
 import { useBottomTabOnPress } from '../_layout'
 
@@ -365,9 +374,15 @@ const InformationSection = () => {
   )
 }
 
+const ALL_ROLES_OPTION: Option = { value: '', label: 'ทั้งหมด' }
+
 const MiniAppSection = () => {
   const router = useRouter()
-  const { data: miniAppData } = reactQueryClient.useQuery('/mini-app', {})
+  const [selectedRole, setSelectedRole] = useState<Option | undefined>(ALL_ROLES_OPTION)
+  const profileQuery = reactQueryClient.useQuery('/profile/me', {})
+  const { data: miniAppData } = reactQueryClient.useQuery('/mini-app', {
+    query: selectedRole?.value ? { role: selectedRole.value } : {},
+  })
 
   const miniAppGroupByTwo = useMemo(() => {
     if (!miniAppData) {
@@ -388,11 +403,26 @@ const MiniAppSection = () => {
 
   return (
     <View className="px-4">
-      <View className="flex flex-row gap-2 items-center">
-        <View className="w-8 h-8 flex items-center justify-center">
-          <Icon icon={PanelsTopLeftIcon} size={32} className="text-base-primary-default" />
+      <View className="flex flex-row justify-between items-center">
+        <View className="flex flex-row gap-2 items-center">
+          <View className="w-8 h-8 flex items-center justify-center">
+            <Icon icon={PanelsTopLeftIcon} size={32} className="text-base-primary-default" />
+          </View>
+          <H2 className="text-2xl font-heading-semibold text-base-text-high">มินิแอปฯ</H2>
         </View>
-        <H2 className="text-2xl font-heading-semibold text-base-text-high">มินิแอปฯ</H2>
+        {profileQuery.data && profileQuery.data.roles.length > 0 && (
+          <Select value={selectedRole} onValueChange={setSelectedRole}>
+            <SelectTrigger className="min-w-[120px]">
+              <SelectValue placeholder="ทั้งหมด" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem label="ทั้งหมด" value="" />
+              {profileQuery.data.roles.map((role) => (
+                <SelectItem key={role} label={getRoleName([role])} value={role} />
+              ))}
+            </SelectContent>
+          </Select>
+        )}
       </View>
       <View className="flex flex-col gap-4 mt-4 items-center">
         {miniAppGroupByTwo.map((group, index) => (

--- a/apps-client/mobile/app/(tabs)/_layout.tsx
+++ b/apps-client/mobile/app/(tabs)/_layout.tsx
@@ -72,7 +72,7 @@ export default function BottomTabsLayout() {
           <Tabs.Screen
             name="(official)"
             options={{
-              title: 'ทางการ',
+              title: 'แอป',
               tabBarIcon: (props) => <TabBarIcon {...props} icon={PPLEIcon} />,
               tabBarLabel: TabBarLabel,
               tabBarButton: TabBarButton,

--- a/apps-client/mobile/app/(tabs)/_layout.tsx
+++ b/apps-client/mobile/app/(tabs)/_layout.tsx
@@ -72,7 +72,7 @@ export default function BottomTabsLayout() {
           <Tabs.Screen
             name="(official)"
             options={{
-              title: 'แอป',
+              title: 'แอปฯ',
               tabBarIcon: (props) => <TabBarIcon {...props} icon={PPLEIcon} />,
               tabBarLabel: TabBarLabel,
               tabBarButton: TabBarButton,

--- a/apps-client/mobile/app/_layout.tsx
+++ b/apps-client/mobile/app/_layout.tsx
@@ -49,6 +49,7 @@ import { InfoIcon } from 'lucide-react-native'
 import { StatusBarProvider } from '@app/context/status-bar'
 import { environment } from '@app/env'
 import { reactQueryClient } from '@app/libs/api-client'
+import { useScreenTracking } from '@app/libs/analytics'
 import { AuthLifeCycleHook, useAuthMe } from '@app/libs/auth'
 import { openLink } from '@app/utils/link'
 
@@ -101,6 +102,7 @@ export default function RootLayout() {
             <DevToolsBubble onCopy={onCopy} queryClient={queryClient} />
           )}
           <AuthLifeCycleHook />
+          <AnalyticsScreenTracker />
           <NotificationTokenConsentPopup />
         </QueryClientProvider>
       </SafeAreaProvider>
@@ -178,6 +180,11 @@ function ColorSchemeProvider({ children }: { children: React.ReactNode }) {
 
 // const useIsomorphicLayoutEffect =
 //   Platform.OS === 'web' && typeof window === 'undefined' ? React.useEffect : React.useLayoutEffect
+
+function AnalyticsScreenTracker() {
+  useScreenTracking()
+  return null
+}
 
 async function requestUserPermission() {
   if (Platform.OS === 'android' && Platform.Version >= 33) {

--- a/apps-client/mobile/app/_layout.tsx
+++ b/apps-client/mobile/app/_layout.tsx
@@ -46,10 +46,12 @@ import { Stack } from 'expo-router'
 import * as SplashScreen from 'expo-splash-screen'
 import { InfoIcon } from 'lucide-react-native'
 
+import { AppUpdateGate } from '@app/components/app-update-gate'
 import { StatusBarProvider } from '@app/context/status-bar'
 import { environment } from '@app/env'
-import { reactQueryClient } from '@app/libs/api-client'
 import { useScreenTracking } from '@app/libs/analytics'
+import { reactQueryClient } from '@app/libs/api-client'
+import { initAppUpdate } from '@app/libs/app-update'
 import { AuthLifeCycleHook, useAuthMe } from '@app/libs/auth'
 import { openLink } from '@app/utils/link'
 
@@ -76,6 +78,8 @@ export {
 } from 'expo-router'
 
 const messaging = getMessaging()
+
+initAppUpdate()
 
 const queryClient = new QueryClient()
 export default function RootLayout() {
@@ -104,6 +108,7 @@ export default function RootLayout() {
           <AuthLifeCycleHook />
           <AnalyticsScreenTracker />
           <NotificationTokenConsentPopup />
+          <AppUpdateGate />
         </QueryClientProvider>
       </SafeAreaProvider>
       <PortalHost />

--- a/apps-client/mobile/components/app-update-gate.tsx
+++ b/apps-client/mobile/components/app-update-gate.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react'
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@pple-today/ui/alert-dialog'
+import { Text } from '@pple-today/ui/text'
+
+import { openStore, useAppUpdateStatus } from '@app/libs/app-update'
+
+export function AppUpdateGate() {
+  const status = useAppUpdateStatus()
+  const [dismissed, setDismissed] = React.useState(false)
+  const statusKey = status ? `${status.mode}:${status.targetVersion}` : null
+  React.useEffect(() => {
+    if (statusKey) setDismissed(false)
+  }, [statusKey])
+
+  if (!status) return null
+
+  const { mode, targetVersion, storeUrl, alert } = status
+  const message = alert.message.replace('{{version}}', targetVersion)
+  const isHard = mode === 'hard'
+  const open = isHard || !dismissed
+
+  return (
+    <AlertDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (isHard) return
+        if (!next) setDismissed(true)
+      }}
+    >
+      <AlertDialogContent className="max-w-xs">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{alert.title}</AlertDialogTitle>
+          <AlertDialogDescription>{message}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          {!isHard && (
+            <AlertDialogCancel onPress={() => setDismissed(true)}>
+              <Text>{alert.laterButton}</Text>
+            </AlertDialogCancel>
+          )}
+          <AlertDialogAction onPress={() => openStore(storeUrl)}>
+            <Text>{alert.downloadButton}</Text>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps-client/mobile/components/playground.tsx
+++ b/apps-client/mobile/components/playground.tsx
@@ -1171,7 +1171,7 @@ function FrontCameraExample() {
 
 function MiniAppExample() {
   const router = useRouter()
-  const miniApps = reactQueryClient.useQuery('/mini-app', {})
+  const miniApps = reactQueryClient.useQuery('/mini-app', { query: {} })
 
   return (
     <View className="flex flex-col gap-2">

--- a/apps-client/mobile/libs/analytics.ts
+++ b/apps-client/mobile/libs/analytics.ts
@@ -1,31 +1,34 @@
 import { useEffect, useRef } from 'react'
 
-import { getAnalytics, logScreenView } from '@react-native-firebase/analytics'
-import { usePathname, useSegments } from 'expo-router'
+import { getAnalytics, logEvent } from '@react-native-firebase/analytics'
+import { useRootNavigationState, useSegments } from 'expo-router'
 
 const analytics = getAnalytics()
 
-function getScreenName(segments: string[]): string {
-  const filtered = segments.filter((s) => !s.startsWith('(') || !s.endsWith(')'))
-  return filtered.length > 0 ? filtered.join('/') : 'index'
-}
-
 export function useScreenTracking() {
-  const pathname = usePathname()
   const segments = useSegments()
-  const previousPathname = useRef<string | null>(null)
+  const navigationState = useRootNavigationState()
+  const previousScreen = useRef<string | null>(null)
 
   useEffect(() => {
-    if (pathname === previousPathname.current) return
-    previousPathname.current = pathname
+    if (!navigationState?.key) return
 
-    const screenName = getScreenName(segments)
+    const screenName =
+      segments
+        .filter((s) => s !== '(tabs)')
+        .map((s) => s.replace(/[()]/g, ''))
+        .join('/') || 'home'
 
-    logScreenView(analytics, {
+    if (screenName === previousScreen.current) return
+    previousScreen.current = screenName
+
+    logEvent(analytics, 'screen_view' as any, {
       screen_name: screenName,
       screen_class: screenName,
-    }).catch((err: unknown) => {
-      console.warn('[Analytics] Failed to log screen view:', err)
-    })
-  }, [pathname, segments])
+    }).catch(() => {})
+
+    if (__DEV__) {
+      console.log(`[Analytics] 🚀 Tracked: ${screenName}`)
+    }
+  }, [segments, navigationState])
 }

--- a/apps-client/mobile/libs/analytics.ts
+++ b/apps-client/mobile/libs/analytics.ts
@@ -1,0 +1,31 @@
+import { useEffect, useRef } from 'react'
+
+import { getAnalytics, logScreenView } from '@react-native-firebase/analytics'
+import { usePathname, useSegments } from 'expo-router'
+
+const analytics = getAnalytics()
+
+function getScreenName(segments: string[]): string {
+  const filtered = segments.filter((s) => !s.startsWith('(') || !s.endsWith(')'))
+  return filtered.length > 0 ? filtered.join('/') : 'index'
+}
+
+export function useScreenTracking() {
+  const pathname = usePathname()
+  const segments = useSegments()
+  const previousPathname = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (pathname === previousPathname.current) return
+    previousPathname.current = pathname
+
+    const screenName = getScreenName(segments)
+
+    logScreenView(analytics, {
+      screen_name: screenName,
+      screen_class: screenName,
+    }).catch((err: unknown) => {
+      console.warn('[Analytics] Failed to log screen view:', err)
+    })
+  }, [pathname, segments])
+}

--- a/apps-client/mobile/libs/app-update.ts
+++ b/apps-client/mobile/libs/app-update.ts
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react'
+import { AppState, Linking, Platform } from 'react-native'
+
+import {
+  fetchAndActivate,
+  getRemoteConfig,
+  getValue,
+  setConfigSettings,
+  setDefaults,
+} from '@react-native-firebase/remote-config'
+import Constants from 'expo-constants'
+import semver from 'semver'
+import { z } from 'zod'
+
+import packageJson from '../package.json'
+
+const REMOTE_CONFIG_KEY = 'CHECK_APP_UPDATE'
+
+const PlatformConfigSchema = z.object({
+  isForceUpdate: z.boolean(),
+  version: z.string(),
+  url: z.string(),
+})
+
+const AppUpdateConfigSchema = z.object({
+  ios: PlatformConfigSchema,
+  android: PlatformConfigSchema,
+  alert: z.object({
+    title: z.string(),
+    message: z.string(),
+    downloadButton: z.string(),
+    laterButton: z.string(),
+  }),
+})
+
+type AppUpdateConfig = z.infer<typeof AppUpdateConfigSchema>
+
+const DEFAULT_CONFIG: AppUpdateConfig = {
+  ios: { isForceUpdate: false, version: '0.0.0', url: '' },
+  android: { isForceUpdate: false, version: '0.0.0', url: '' },
+  alert: {
+    title: '',
+    message: '',
+    downloadButton: 'อัปเดตตอนนี้',
+    laterButton: 'ไว้ทีหลัง',
+  },
+}
+
+export type AppUpdateStatus = {
+  mode: 'soft' | 'hard'
+  targetVersion: string
+  storeUrl: string
+  alert: AppUpdateConfig['alert']
+}
+
+let initialized = false
+
+export function initAppUpdate() {
+  if (initialized) return
+  initialized = true
+  const remoteConfig = getRemoteConfig()
+  setConfigSettings(remoteConfig, {
+    minimumFetchIntervalMillis: __DEV__ ? 0 : 60 * 60 * 1000,
+    fetchTimeMillis: 60 * 1000,
+  })
+  setDefaults(remoteConfig, {
+    [REMOTE_CONFIG_KEY]: JSON.stringify(DEFAULT_CONFIG),
+  }).catch((err) => {
+    if (__DEV__) console.warn('[AppUpdate] setDefaults failed', err)
+  })
+}
+
+function getCurrentVersion(): string {
+  return Constants.expoConfig?.version ?? packageJson.version
+}
+
+function coerceSemver(value: string): string | null {
+  const coerced = semver.coerce(value)
+  return coerced ? coerced.version : null
+}
+
+async function readConfig(): Promise<AppUpdateConfig | null> {
+  try {
+    const remoteConfig = getRemoteConfig()
+    await fetchAndActivate(remoteConfig)
+    const raw = getValue(remoteConfig, REMOTE_CONFIG_KEY).asString()
+    if (!raw) return null
+    const parsed = AppUpdateConfigSchema.safeParse(JSON.parse(raw))
+    if (!parsed.success) {
+      if (__DEV__) console.warn('[AppUpdate] invalid remote config', parsed.error)
+      return null
+    }
+    return parsed.data
+  } catch (err) {
+    if (__DEV__) console.warn('[AppUpdate] fetch failed', err)
+    return null
+  }
+}
+
+function evaluateStatus(config: AppUpdateConfig): AppUpdateStatus | null {
+  const platform =
+    Platform.OS === 'ios' ? config.ios : Platform.OS === 'android' ? config.android : null
+  if (!platform) return null
+
+  const current = coerceSemver(getCurrentVersion())
+  const target = coerceSemver(platform.version)
+  if (!current || !target) return null
+  if (!semver.lt(current, target)) return null
+
+  return {
+    mode: platform.isForceUpdate ? 'hard' : 'soft',
+    targetVersion: platform.version,
+    storeUrl: platform.url,
+    alert: config.alert,
+  }
+}
+
+export function useAppUpdateStatus(): AppUpdateStatus | null {
+  const [status, setStatus] = useState<AppUpdateStatus | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const refresh = async () => {
+      const config = await readConfig()
+
+      if (cancelled) return
+      setStatus(config ? evaluateStatus(config) : null)
+    }
+
+    refresh()
+
+    const subscription = AppState.addEventListener('change', (next) => {
+      if (next === 'active') refresh()
+    })
+
+    return () => {
+      cancelled = true
+      subscription.remove()
+    }
+  }, [])
+  return status
+}
+
+export async function openStore(url: string) {
+  if (!url) return
+  try {
+    await Linking.openURL(url)
+  } catch (err) {
+    if (__DEV__) console.warn('[AppUpdate] openStore failed', err)
+  }
+}

--- a/apps-client/mobile/package.json
+++ b/apps-client/mobile/package.json
@@ -37,6 +37,7 @@
     "@react-native-firebase/analytics": "^23.4.1",
     "@react-native-firebase/app": "^23.4.1",
     "@react-native-firebase/messaging": "^23.4.1",
+    "@react-native-firebase/remote-config": "23.4.1",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/material-top-tabs": "^7.3.2",
@@ -93,6 +94,7 @@
     "react-native-webview": "13.15.0",
     "react-native-worklets": "^0.5.2",
     "react-query-kit": "^3.3.1",
+    "semver": "^7.6.0",
     "zod": "^4.0.5"
   },
   "devDependencies": {
@@ -101,6 +103,7 @@
     "@pple-today/project-config": "workspace:^",
     "@tanstack/eslint-plugin-query": "^5.81.2",
     "@types/node-forge": "^1.3.14",
+    "@types/semver": "^7.5.8",
     "@types/react": "~19.1.5",
     "@types/react-dom": "19.1.5",
     "prettier-plugin-tailwindcss": "^0.5.11",

--- a/apps-client/mobile/package.json
+++ b/apps-client/mobile/package.json
@@ -34,6 +34,7 @@
     "@gorhom/bottom-sheet": "^5.2.4",
     "@pple-today/api-client": "workspace:^",
     "@pple-today/ui": "workspace:^",
+    "@react-native-firebase/analytics": "^23.4.1",
     "@react-native-firebase/app": "^23.4.1",
     "@react-native-firebase/messaging": "^23.4.1",
     "@react-navigation/bottom-tabs": "^7.3.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,9 @@ importers:
       '@pple-today/ui':
         specifier: workspace:^
         version: link:../../packages/ui
+      '@react-native-firebase/analytics':
+        specifier: ^23.4.1
+        version: 23.4.1(@react-native-firebase/app@23.4.1(expo@54.0.21(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))
       '@react-native-firebase/app':
         specifier: ^23.4.1
         version: 23.4.1(expo@54.0.21(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)
@@ -3675,6 +3678,11 @@ packages:
     resolution: {integrity: sha512-DyKptlG78XPFo7tDod+we5a3R+U9qjyhaVFbOPvH4pFNu5Dehewtol/srl44K6Cszq0aEMlAJZ3juk0W4WnOJA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@react-native-firebase/analytics@23.4.1':
+    resolution: {integrity: sha512-9yuWIrdiBIXsgmnOCYOJNOXS4cMWfYgorBey39BLa/P7wwVBZvTSg4yw6gtsHjkg/ptAMaCRItpBF6rd2k+1uw==}
+    peerDependencies:
+      '@react-native-firebase/app': 23.4.1
 
   '@react-native-firebase/app@23.4.1':
     resolution: {integrity: sha512-AVxk9dS3plHjIUDWUlKSEAbKrEtGweLZXEMZpJokvLyNbeL1i4dDAUkDriPzjIEgtxaFX3rUxFuBRQvLHlsmAA==}
@@ -10154,6 +10162,10 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
 
+  superstruct@2.0.2:
+    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
+    engines: {node: '>=14.0.0'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -10212,6 +10224,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   teeny-request@10.1.0:
     resolution: {integrity: sha512-3ZnLvgWF29jikg1sAQ1g0o+lr5JX6sVgYvfUJazn7ZjJroDBUTWp44/+cFVX0bULjv4vci+rBD+oGVAkWqhUbw==}
@@ -10942,6 +10955,7 @@ packages:
   whatwg-encoding@2.0.0:
     resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
     engines: {node: '>=12'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-fetch@3.6.20:
     resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
@@ -15823,6 +15837,11 @@ snapshots:
       - typescript
       - utf-8-validate
     optional: true
+
+  '@react-native-firebase/analytics@23.4.1(@react-native-firebase/app@23.4.1(expo@54.0.21(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))':
+    dependencies:
+      '@react-native-firebase/app': 23.4.1(expo@54.0.21(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)
+      superstruct: 2.0.2
 
   '@react-native-firebase/app@23.4.1(expo@54.0.21(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)':
     dependencies:
@@ -24550,6 +24569,8 @@ snapshots:
       mz: 2.7.0
       pirates: 4.0.7
       ts-interface-checker: 0.1.13
+
+  superstruct@2.0.2: {}
 
   supports-color@5.5.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       '@react-native-firebase/messaging':
         specifier: ^23.4.1
         version: 23.4.1(d6fitcigmucu2zchdzid3smhui)
+      '@react-native-firebase/remote-config':
+        specifier: 23.4.1
+        version: 23.4.1(pe64l535onz6afuyq6cmwdk4x4)
       '@react-navigation/bottom-tabs':
         specifier: ^7.3.10
         version: 7.3.12(@react-navigation/native@7.1.8(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)
@@ -502,6 +505,9 @@ importers:
       react-query-kit:
         specifier: ^3.3.1
         version: 3.3.1(@tanstack/react-query@5.81.5(react@19.1.5))
+      semver:
+        specifier: ^7.6.0
+        version: 7.7.3
       zod:
         specifier: ^4.0.5
         version: 4.0.5
@@ -527,6 +533,9 @@ importers:
       '@types/react-dom':
         specifier: 19.1.5
         version: 19.1.5(@types/react@19.1.5)
+      '@types/semver':
+        specifier: ^7.5.8
+        version: 7.7.1
       prettier-plugin-tailwindcss:
         specifier: ^0.5.11
         version: 0.5.14(prettier@3.6.2)
@@ -3703,6 +3712,12 @@ packages:
       expo:
         optional: true
 
+  '@react-native-firebase/remote-config@23.4.1':
+    resolution: {integrity: sha512-DNdC8wmIL1shZduh9L/94ZfP6yaZ/TnzNMuwkNli1U8LjgQNGAKH/8uM5oIgaH8TapetW0ua3IaAWZ/wupLONQ==}
+    peerDependencies:
+      '@react-native-firebase/analytics': 23.4.1
+      '@react-native-firebase/app': 23.4.1
+
   '@react-native/assets-registry@0.81.5':
     resolution: {integrity: sha512-705B6x/5Kxm1RKRvSv0ADYWm5JOnoiQ1ufW7h8uu2E6G9Of/eE6hP/Ivw3U5jI16ERqZxiKQwk34VJbB0niX9w==}
     engines: {node: '>= 20.19.4'}
@@ -4816,6 +4831,9 @@ packages:
 
   '@types/request@2.48.13':
     resolution: {integrity: sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==}
+
+  '@types/semver@7.7.1':
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -10291,6 +10309,10 @@ packages:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
 
+  text-encoding@0.7.0:
+    resolution: {integrity: sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==}
+    deprecated: no longer maintained
+
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
     engines: {node: '>=0.8'}
@@ -12757,7 +12779,7 @@ snapshots:
       package-manager-detector: 0.2.11
       picocolors: 1.1.1
       resolve-from: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.3
       spawndamnit: 3.0.1
       term-size: 2.2.1
 
@@ -13087,7 +13109,7 @@ snapshots:
       resolve: 1.22.10
       resolve-from: 5.0.0
       resolve.exports: 2.0.3
-      semver: 7.7.2
+      semver: 7.7.3
       send: 0.19.0
       slugify: 1.6.6
       source-map-support: 0.5.21
@@ -13164,7 +13186,7 @@ snapshots:
       resolve: 1.22.10
       resolve-from: 5.0.0
       resolve.exports: 2.0.3
-      semver: 7.7.2
+      semver: 7.7.3
       send: 0.19.0
       slugify: 1.6.6
       source-map-support: 0.5.21
@@ -13241,7 +13263,7 @@ snapshots:
       resolve: 1.22.10
       resolve-from: 5.0.0
       resolve.exports: 2.0.3
-      semver: 7.7.2
+      semver: 7.7.3
       send: 0.19.0
       slugify: 1.6.6
       source-map-support: 0.5.21
@@ -13297,7 +13319,7 @@ snapshots:
       getenv: 2.0.0
       glob: 10.4.5
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.3
       slash: 3.0.0
       slugify: 1.6.6
       xcode: 3.0.1
@@ -13339,7 +13361,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
       resolve-workspace-root: 2.0.0
-      semver: 7.7.2
+      semver: 7.7.3
       slugify: 1.6.6
       sucrase: 3.35.0
     transitivePeerDependencies:
@@ -13396,7 +13418,7 @@ snapshots:
       minimatch: 9.0.5
       p-limit: 3.1.0
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13612,7 +13634,7 @@ snapshots:
       debug: 4.4.1
       expo: 54.0.21(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.3
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
@@ -13628,7 +13650,7 @@ snapshots:
       debug: 4.4.1
       expo: 54.0.21(@babel/core@7.28.4)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.28.4)(@react-native-community/cli@18.0.0(typescript@5.8.2))(@types/react@19.1.5)(react@19.1.5)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.28.4)(@react-native-community/cli@18.0.0(typescript@5.8.2))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.28.4)(@react-native-community/cli@18.0.0(typescript@5.8.2))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.3
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
@@ -13644,7 +13666,7 @@ snapshots:
       debug: 4.4.1
       expo: 54.0.21(@babel/core@7.28.4)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.28.4)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.0.0)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.28.4)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.0.0))(react@19.0.0))(react-native@0.81.5(@babel/core@7.28.4)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.0.0))(react@19.0.0)
       resolve-from: 5.0.0
-      semver: 7.7.2
+      semver: 7.7.3
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
@@ -14495,7 +14517,7 @@ snapshots:
       json-parse-even-better-errors: 3.0.2
       normalize-package-data: 5.0.0
       proc-log: 3.0.0
-      semver: 7.7.2
+      semver: 7.7.3
     transitivePeerDependencies:
       - bluebird
 
@@ -15859,6 +15881,12 @@ snapshots:
     optionalDependencies:
       expo: 54.0.21(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)
 
+  '@react-native-firebase/remote-config@23.4.1(pe64l535onz6afuyq6cmwdk4x4)':
+    dependencies:
+      '@react-native-firebase/analytics': 23.4.1(@react-native-firebase/app@23.4.1(expo@54.0.21(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))
+      '@react-native-firebase/app': 23.4.1(expo@54.0.21(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)
+      text-encoding: 0.7.0
+
   '@react-native/assets-registry@0.81.5': {}
 
   '@react-native/babel-plugin-codegen@0.79.5(@babel/core@7.28.4)':
@@ -16072,7 +16100,7 @@ snapshots:
       metro: 0.83.2
       metro-config: 0.83.2
       metro-core: 0.83.2
-      semver: 7.7.2
+      semver: 7.7.3
     optionalDependencies:
       '@react-native-community/cli': 18.0.0(typescript@5.8.2)
     transitivePeerDependencies:
@@ -16088,7 +16116,7 @@ snapshots:
       metro: 0.83.2
       metro-config: 0.83.2
       metro-core: 0.83.2
-      semver: 7.7.2
+      semver: 7.7.3
     optionalDependencies:
       '@react-native-community/cli': 18.0.0(typescript@5.8.3)
     transitivePeerDependencies:
@@ -16398,7 +16426,7 @@ snapshots:
       prettier: 3.6.2
       react-refresh: 0.14.2
       react-router: 7.8.2(react-dom@19.1.5(react@19.1.5))(react@19.1.5)
-      semver: 7.7.2
+      semver: 7.7.3
       set-cookie-parser: 2.7.1
       tinyglobby: 0.2.14
       valibot: 0.41.0(typescript@5.8.3)
@@ -17423,6 +17451,8 @@ snapshots:
       '@types/node': 22.15.3
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.5
+
+  '@types/semver@7.7.1': {}
 
   '@types/stack-utils@2.0.3': {}
 
@@ -19802,7 +19832,7 @@ snapshots:
     dependencies:
       ajv: 8.17.1
       expo: 54.0.21(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)
-      semver: 7.7.2
+      semver: 7.7.3
 
   expo-clipboard@8.0.7(expo@54.0.21(@babel/core@7.27.1)(@expo/metro-runtime@5.0.4(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5)))(expo-router@6.0.14)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5):
     dependencies:
@@ -23284,7 +23314,7 @@ snapshots:
       react: 19.1.5
       react-native: 0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5)
       react-native-reanimated: 4.2.0-nightly-20251029-bca463bf9(react-native-worklets@0.5.2(@babel/core@7.27.1)(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)
-      semver: 7.7.2
+      semver: 7.7.3
       tailwindcss: 3.4.17
     optionalDependencies:
       react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.27.1)(@react-native-community/cli@18.0.0(typescript@5.8.3))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)
@@ -23302,7 +23332,7 @@ snapshots:
       react: 19.1.5
       react-native: 0.81.5(@babel/core@7.28.4)(@react-native-community/cli@18.0.0(typescript@5.8.2))(@types/react@19.1.5)(react@19.1.5)
       react-native-reanimated: 4.2.0-nightly-20251029-bca463bf9(react-native-worklets@0.5.2(@babel/core@7.28.4)(react-native@0.81.5(@babel/core@7.28.4)(@react-native-community/cli@18.0.0(typescript@5.8.2))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5))(react-native@0.81.5(@babel/core@7.28.4)(@react-native-community/cli@18.0.0(typescript@5.8.2))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)
-      semver: 7.7.2
+      semver: 7.7.3
       tailwindcss: 3.4.17
     optionalDependencies:
       react-native-safe-area-context: 5.6.2(react-native@0.81.5(@babel/core@7.28.4)(@react-native-community/cli@18.0.0(typescript@5.8.2))(@types/react@19.1.5)(react@19.1.5))(react@19.1.5)
@@ -23648,7 +23678,7 @@ snapshots:
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
       scheduler: 0.26.0
-      semver: 7.7.2
+      semver: 7.7.3
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
       ws: 6.2.3
@@ -23695,7 +23725,7 @@ snapshots:
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
       scheduler: 0.26.0
-      semver: 7.7.2
+      semver: 7.7.3
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
       ws: 6.2.3
@@ -23742,7 +23772,7 @@ snapshots:
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
       scheduler: 0.26.0
-      semver: 7.7.2
+      semver: 7.7.3
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
       ws: 6.2.3
@@ -24729,6 +24759,8 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 10.4.5
       minimatch: 9.0.5
+
+  text-encoding@0.7.0: {}
 
   thenify-all@1.6.0:
     dependencies:


### PR DESCRIPTION
# Summary

- **Firebase Analytics integration**: Added screen tracking using `@react-native-firebase/analytics` with automatic route-based screen view logging
- **Mini App API enhancement**: Added optional `role` query parameter to the `/mini-app` endpoint, allowing clients to filter mini apps by a specific role instead of using all user roles
- **UI updates**:  restructured the activity and official section layouts

# Screenshots/Video

# Steps to Test

1.
2.
3.

# Checklist

- [ ] Add Changeset
- [ ] Add Linear ID in PR title
- [ ] Perform Manual Testing

> [!NOTE]
- This PR was moved from #372 
